### PR TITLE
[FEAT] 처음 접속한 사용자 추가 설정(마케팅 정보 동의 여부, 선호하는 책 취향 태그, 정보 공개 여부) 등록 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,16 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-devtools'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+	//SpringSecurity
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//JWT
+	implementation 'com.auth0:java-jwt:4.2.1'
+
+	//OAuth
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	//SpringSecurity
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.core.book.api.member.controller;
+
+import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.repository.MemberRepository;
+import com.core.book.common.exception.NotFoundException;
+import com.core.book.common.response.ApiResponse;
+import com.core.book.common.response.ErrorStatus;
+import com.core.book.common.response.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberRepository memberRepository;
+
+    // 사용자 토큰 인증 확인용 임시 API 입니다.
+    @GetMapping("/check")
+    public ApiResponse<Member> getMemberDetails(@AuthenticationPrincipal UserDetails userDetails) {
+        Member member = memberRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+       return ApiResponse.success(SuccessStatus.SEND_USERDETAIL_SUCCESS, member);
+    }
+}

--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -1,30 +1,72 @@
 package com.core.book.api.member.controller;
 
+import com.core.book.api.member.dto.UserTagRequestDTO;
 import com.core.book.api.member.entity.Member;
-import com.core.book.api.member.repository.MemberRepository;
-import com.core.book.common.exception.NotFoundException;
+import com.core.book.api.member.service.MemberService;
 import com.core.book.common.response.ApiResponse;
-import com.core.book.common.response.ErrorStatus;
 import com.core.book.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import jakarta.servlet.http.HttpServletResponse;
+
+@Tag(name = "Member", description = "Member 관련 API 입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
 public class MemberController {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     // 사용자 토큰 인증 확인용 임시 API 입니다.
+    @Operation(
+            summary = "[임시]")
     @GetMapping("/check")
     public ApiResponse<Member> getMemberDetails(@AuthenticationPrincipal UserDetails userDetails) {
-        Member member = memberRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
-       return ApiResponse.success(SuccessStatus.SEND_USERDETAIL_SUCCESS, member);
+        Member member = memberService.getMemberDetails(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.SEND_USERDETAIL_SUCCESS, member);
+    }
+
+    // 최초 회원가입 사용자 유저 태그 등록 API
+    @Operation(
+            summary = "처음 사용자용 TAG 등록 API",
+            description = "처음 사용자 추가 정보 등록페이지 에서 TAG를 등록하고 기존사용자로 변경합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "USERTAG 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "최소 한개 이상의 USERTAG가 발송되지 않았습니다.")
+    })
+    @PostMapping("/initial-tags")
+    public ApiResponse<Void> registerInitialTags(@AuthenticationPrincipal UserDetails userDetails, @RequestBody UserTagRequestDTO userTagRequest, HttpServletResponse response) {
+
+        memberService.registerInitialTags(userDetails.getUsername(), userTagRequest, response);
+        return ApiResponse.success_only(SuccessStatus.CREATE_USERTAG_SUCCESS);
+    }
+
+    // 최초 회원가입 사용자 마케팅 동의 여부 등록 API (approve = ok : 승인 / approve = no : 미승인)
+    @Operation(
+            summary = "처음 사용자용 마케팅 정보 동의 등록 API",
+            description = "처음 사용자 추가 정보 등록페이지 에서 마케팅 동의 여부를 확인 후 동의 여부 등록합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 마케팅 동의 여부 설정 성공"),
+    })
+    @GetMapping("/initial-marketing")
+    public ApiResponse<Void> registerInitialMarketing(@AuthenticationPrincipal UserDetails userDetails,
+                                                      @Parameter(
+                                                              description = "사용자의 마케팅 동의 여부를 나타내는 파라미터로, 'ok'는 승인, 'no'는 미승인을 의미합니다.",
+                                                              example = "ok",
+                                                              in = ParameterIn.QUERY)
+                                                      @RequestParam String approve) {
+
+        memberService.registerInitialMarketing(userDetails.getUsername(), approve);
+        return ApiResponse.success_only(SuccessStatus.SET_USER_MARKETING_SUCCESS);
     }
 }

--- a/src/main/java/com/core/book/api/member/dto/UserTagRequestDTO.java
+++ b/src/main/java/com/core/book/api/member/dto/UserTagRequestDTO.java
@@ -1,0 +1,15 @@
+package com.core.book.api.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserTagRequestDTO {
+
+    private final String tag1;
+    private final String tag2;
+    private final String tag3;
+    private final String tag4;
+    private final String tag5;
+}

--- a/src/main/java/com/core/book/api/member/entity/InfoOpen.java
+++ b/src/main/java/com/core/book/api/member/entity/InfoOpen.java
@@ -1,0 +1,30 @@
+package com.core.book.api.member.entity;
+
+import com.core.book.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Builder(toBuilder = true)
+@Table(name = "INFO_OPEN")
+@AllArgsConstructor
+
+public class InfoOpen extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "info_open_id")
+    private Long id;
+
+    private Boolean follow_open; // 팔로우 공개 여부
+    private Boolean content_open; // 글 공개 여부
+    private Boolean comment_open; // 댓글 공개 여부
+    private Boolean like_open; // 좋아요 공개 여부
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Member member;
+
+}

--- a/src/main/java/com/core/book/api/member/entity/Member.java
+++ b/src/main/java/com/core/book/api/member/entity/Member.java
@@ -6,14 +6,13 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import jakarta.persistence.*;
-
 import java.util.Collection;
 import java.util.Collections;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Builder
+@Builder(toBuilder = true)  // toBuilder 옵션을 사용하여 기존 객체를 복사하는 빌더 생성 가능
 @Table(name = "MEMBER")
 @AllArgsConstructor
 public class Member extends BaseTimeEntity implements UserDetails {
@@ -26,6 +25,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
     private String email; // 이메일
     private String nickname; // 닉네임
     private String imageUrl; // 프로필 이미지
+    private Boolean marketing_allow;
 
     @Enumerated(EnumType.STRING)
     private Role role; // 권한
@@ -34,19 +34,37 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     private String refreshToken; // 리프레시 토큰
 
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    private UserTag userTag;
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    private InfoOpen infoOpen;
+
     // 유저 권한 설정 메소드
-    public void authorizeUser() {
-        this.role = Role.USER;
+    public Member authorizeUser() {
+        return this.toBuilder()
+                .role(Role.USER)
+                .build();
     }
 
     // 닉네임 필드 업데이트
-    public void updateNickname(String updateNickname) {
-        this.nickname = updateNickname;
+    public Member updateNickname(String updateNickname) {
+        return this.toBuilder()
+                .nickname(updateNickname)
+                .build();
     }
 
     // 리프레시토큰 필드 업데이트
-    public void updateRefreshToken(String updateRefreshToken) {
-        this.refreshToken = updateRefreshToken;
+    public Member updateRefreshToken(String updateRefreshToken) {
+        return this.toBuilder()
+                .refreshToken(updateRefreshToken)
+                .build();
+    }
+
+    // 마케팅 동의 여부 필드 업데이트
+    public Member updateMarketingAllow(Boolean updateMarketingAllow) {
+        return this.toBuilder()
+                .marketing_allow(updateMarketingAllow)
+                .build();
     }
 
     @Override
@@ -64,4 +82,3 @@ public class Member extends BaseTimeEntity implements UserDetails {
         return null;
     }
 }
-

--- a/src/main/java/com/core/book/api/member/entity/Member.java
+++ b/src/main/java/com/core/book/api/member/entity/Member.java
@@ -1,0 +1,67 @@
+package com.core.book.api.member.entity;
+
+import com.core.book.common.entity.BaseTimeEntity;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import jakarta.persistence.*;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Builder
+@Table(name = "MEMBER")
+@AllArgsConstructor
+public class Member extends BaseTimeEntity implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String email; // 이메일
+    private String nickname; // 닉네임
+    private String imageUrl; // 프로필 이미지
+
+    @Enumerated(EnumType.STRING)
+    private Role role; // 권한
+
+    private String socialId; // 로그인한 소셜 타입의 식별자 값
+
+    private String refreshToken; // 리프레시 토큰
+
+    // 유저 권한 설정 메소드
+    public void authorizeUser() {
+        this.role = Role.USER;
+    }
+
+    // 닉네임 필드 업데이트
+    public void updateNickname(String updateNickname) {
+        this.nickname = updateNickname;
+    }
+
+    // 리프레시토큰 필드 업데이트
+    public void updateRefreshToken(String updateRefreshToken) {
+        this.refreshToken = updateRefreshToken;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(() -> this.role.getKey());
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+}
+

--- a/src/main/java/com/core/book/api/member/entity/Role.java
+++ b/src/main/java/com/core/book/api/member/entity/Role.java
@@ -1,0 +1,13 @@
+package com.core.book.api.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    GUEST("ROLE_GUEST"), USER("ROLE_USER");
+
+    private final String key;
+}

--- a/src/main/java/com/core/book/api/member/entity/UserTag.java
+++ b/src/main/java/com/core/book/api/member/entity/UserTag.java
@@ -1,0 +1,30 @@
+package com.core.book.api.member.entity;
+
+import com.core.book.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Builder
+@Table(name = "USER_TAG")
+@AllArgsConstructor
+public class UserTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_tag_id")
+    private Long id;
+
+    private String tag1; // 유저가 선택한 태그
+    private String tag2;
+    private String tag3;
+    private String tag4;
+    private String tag5;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Member member;
+
+}

--- a/src/main/java/com/core/book/api/member/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/core/book/api/member/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,111 @@
+package com.core.book.api.member.jwt.filter;
+
+import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.repository.MemberRepository;
+import com.core.book.api.member.jwt.service.JwtService;
+import com.core.book.api.member.jwt.util.PasswordUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+    private static final String NO_CHECK_URL = "/oauth2/authorization/kakao"; // 이 엔드포인트로 들어오는 요청은 Filter 작동 X
+
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().equals(NO_CHECK_URL)) {
+            filterChain.doFilter(request, response); // "/login" 요청이 들어오면, 다음 필터 호출
+            return; // return으로 이후 현재 필터 진행 막기
+        }
+
+        // 사용자 요청 헤더에서 RefreshToken 추출
+        String refreshToken = jwtService.extractRefreshToken(request)
+                .filter(jwtService::isTokenValid)
+                .orElse(null);
+
+        if (refreshToken != null) {
+            // 리프레시 토큰이 존재하면, 새로운 엑세스 토큰 및 리프레시 토큰을 발급
+            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
+
+            // 새롭게 발급된 엑세스 토큰으로 SecurityContextHolder에 인증 정보 설정
+            jwtService.extractAccessToken(request)
+                    .ifPresent(accessToken -> jwtService.extractEmail(accessToken)
+                            .ifPresent(email -> memberRepository.findByEmail(email)
+                                    .ifPresent(this::saveAuthentication)));
+
+            // 필터 체인을 다시 실행하여 엔드포인트 작업이 수행되도록 함
+            filterChain.doFilter(request, response);
+            return; // 이후 코드 진행 막기
+        }
+
+        // RefreshToken이 없거나 유효하지 않다면, AccessToken을 검사하고 인증을 처리하는 로직 수행
+        checkAccessTokenAndAuthentication(request, response, filterChain);
+    }
+
+    private void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
+        memberRepository.findByRefreshToken(refreshToken)
+                .ifPresent(user -> {
+                    String reIssuedRefreshToken = reIssueRefreshToken(user);
+                    jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(user.getEmail()),
+                            reIssuedRefreshToken);
+                });
+    }
+
+    private String reIssueRefreshToken(Member user) {
+        String reIssuedRefreshToken = jwtService.createRefreshToken();
+        user.updateRefreshToken(reIssuedRefreshToken);
+        memberRepository.saveAndFlush(user);
+        return reIssuedRefreshToken;
+    }
+
+    private void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                                   FilterChain filterChain) throws ServletException, IOException {
+        log.info("checkAccessTokenAndAuthentication() 호출");
+        jwtService.extractAccessToken(request)
+                .filter(jwtService::isTokenValid)
+                .ifPresent(accessToken -> jwtService.extractEmail(accessToken)
+                        .ifPresent(email -> memberRepository.findByEmail(email)
+                                .ifPresent(this::saveAuthentication)));
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void saveAuthentication(Member myUser) {
+        String password = myUser.getPassword();
+        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정하여 소셜 로그인 유저도 인증되도록 설정
+            password = PasswordUtil.generateRandomPassword();
+        }
+
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username(myUser.getEmail())
+                .password(password)
+                .roles(myUser.getRole().name())
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/core/book/api/member/jwt/service/JwtService.java
+++ b/src/main/java/com/core/book/api/member/jwt/service/JwtService.java
@@ -2,13 +2,16 @@ package com.core.book.api.member.jwt.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.core.book.api.member.entity.Member;
 import com.core.book.api.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Date;
@@ -28,12 +31,6 @@ public class JwtService {
 
     @Value("${jwt.refresh.expiration}")
     private Long refreshTokenExpirationPeriod;
-
-    @Value("${jwt.access.header}")
-    private String accessHeader;
-
-    @Value("${jwt.refresh.header}")
-    private String refreshHeader;
 
     private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
@@ -60,30 +57,48 @@ public class JwtService {
     }
 
     public void sendAccessToken(HttpServletResponse response, String accessToken) {
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setHeader(accessHeader, BEARER + accessToken);
+        Cookie accessTokenCookie = createCookie("accessToken", accessToken, accessTokenExpirationPeriod.intValue());
+        response.addCookie(accessTokenCookie);
         log.info("재발급된 Access Token : {}", accessToken);
     }
 
     public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
-        response.setStatus(HttpServletResponse.SC_OK);
-        setAccessTokenHeader(response, accessToken);
-        setRefreshTokenHeader(response, refreshToken);
-        log.info("Access Token, Refresh Token 헤더 설정 완료");
-        log.info("Access Token :{}", accessToken);
-        log.info("Refresh Token :{}", refreshToken);
+        Cookie accessTokenCookie = createCookie("accessToken", accessToken, accessTokenExpirationPeriod.intValue());
+        Cookie refreshTokenCookie = createCookie("refreshToken", refreshToken, refreshTokenExpirationPeriod.intValue());
+
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
+        log.info("Access Token, Refresh Token 쿠키 설정 완료");
+        log.info("Access Token : {}", accessToken);
+        log.info("Refresh Token : {}", refreshToken);
+    }
+
+    private Cookie createCookie(String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);  // "Bearer " 접두사를 제거
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge / 1000); // 쿠키의 maxAge는 초 단위
+        return cookie;
     }
 
     public Optional<String> extractRefreshToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(refreshHeader))
-                .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+        return Optional.ofNullable(getCookieValue(request, "refreshToken"));
     }
 
     public Optional<String> extractAccessToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(accessHeader))
-                .filter(accessToken -> accessToken.startsWith(BEARER))
-                .map(accessToken -> accessToken.replace(BEARER, ""));
+        return Optional.ofNullable(getCookieValue(request, "accessToken"));
+    }
+
+    private String getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName().equals(name)) {
+                    return cookie.getValue().replace(BEARER, "");
+                }
+            }
+        }
+        return null;
     }
 
     public Optional<String> extractEmail(String accessToken) {
@@ -99,20 +114,14 @@ public class JwtService {
         }
     }
 
-    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
-        response.setHeader(accessHeader, BEARER + accessToken);
-    }
-
-    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
-        response.setHeader(refreshHeader, BEARER + refreshToken);
-    }
-
+    @Transactional
     public void updateRefreshToken(String email, String refreshToken) {
-        memberRepository.findByEmail(email)
-                .ifPresent(user -> {
-                    user.updateRefreshToken(refreshToken);
-                    memberRepository.save(user);
-                });
+        memberRepository.findByEmail(email).ifPresent(member -> {
+            Member updatedMember = member.toBuilder()
+                    .refreshToken(refreshToken)
+                    .build();
+            memberRepository.save(updatedMember); // 새로 생성된 객체를 저장
+        });
     }
 
     public boolean isTokenValid(String token) {

--- a/src/main/java/com/core/book/api/member/jwt/service/JwtService.java
+++ b/src/main/java/com/core/book/api/member/jwt/service/JwtService.java
@@ -1,0 +1,127 @@
+package com.core.book.api.member.jwt.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.core.book.api.member.repository.MemberRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class JwtService {
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String BEARER = "Bearer ";
+
+    private final MemberRepository memberRepository;
+
+    public String createAccessToken(String email) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim(EMAIL_CLAIM, email)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public String createRefreshToken() {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public void sendAccessToken(HttpServletResponse response, String accessToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setHeader(accessHeader, BEARER + accessToken);
+        log.info("재발급된 Access Token : {}", accessToken);
+    }
+
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+        log.info("Access Token, Refresh Token 헤더 설정 완료");
+        log.info("Access Token :{}", accessToken);
+        log.info("Refresh Token :{}", refreshToken);
+    }
+
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(accessToken -> accessToken.startsWith(BEARER))
+                .map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractEmail(String accessToken) {
+        try {
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(accessToken)
+                    .getClaim(EMAIL_CLAIM)
+                    .asString());
+        } catch (Exception e) {
+            log.error("액세스 토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, BEARER + accessToken);
+    }
+
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, BEARER + refreshToken);
+    }
+
+    public void updateRefreshToken(String email, String refreshToken) {
+        memberRepository.findByEmail(email)
+                .ifPresent(user -> {
+                    user.updateRefreshToken(refreshToken);
+                    memberRepository.save(user);
+                });
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+            return true;
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/core/book/api/member/jwt/util/PasswordUtil.java
+++ b/src/main/java/com/core/book/api/member/jwt/util/PasswordUtil.java
@@ -1,0 +1,30 @@
+package com.core.book.api.member.jwt.util;
+
+import java.util.Random;
+
+public class PasswordUtil {
+
+    public static String generateRandomPassword() {
+        int index = 0;
+        char[] charSet = new char[] {
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+        };	//배열안의 문자 숫자는 원하는대로
+
+        StringBuffer password = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 8 ; i++) {
+            double rd = random.nextDouble();
+            index = (int) (charSet.length * rd);
+
+            password.append(charSet[index]);
+        }
+        System.out.println(password);
+        return password.toString();
+        //StringBuffer를 String으로 변환해서 return 하려면 toString()을 사용하면 된다.
+    }
+}

--- a/src/main/java/com/core/book/api/member/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/core/book/api/member/oauth2/CustomOAuth2User.java
@@ -1,0 +1,24 @@
+package com.core.book.api.member.oauth2;
+
+import com.core.book.api.member.entity.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private String email;
+    private Role role;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes, String nameAttributeKey,
+                            String email, Role role) {
+        super(authorities, attributes, nameAttributeKey);
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/core/book/api/member/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/core/book/api/member/oauth2/OAuthAttributes.java
@@ -1,0 +1,45 @@
+package com.core.book.api.member.oauth2;
+
+import com.core.book.api.member.entity.Role;
+import lombok.Builder;
+import lombok.Getter;
+import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.oauth2.userinfo.KakaoOAuth2UserInfo;
+import com.core.book.api.member.oauth2.userinfo.OAuth2UserInfo;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Getter
+public class OAuthAttributes {
+
+    private String nameAttributeKey;
+    private OAuth2UserInfo oauth2UserInfo;
+
+    @Builder
+    public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oauth2UserInfo = oauth2UserInfo;
+    }
+
+    public static OAuthAttributes of(String userNameAttributeName, Map<String, Object> attributes) {
+        return ofKakao(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    public Member toEntity(OAuth2UserInfo oauth2UserInfo) {
+        return Member.builder()
+                .socialId(oauth2UserInfo.getId())
+                .email(UUID.randomUUID() + "@socialUser.com")
+                .nickname(oauth2UserInfo.getNickname())
+                .imageUrl(oauth2UserInfo.getImageUrl())
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/com/core/book/api/member/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/core/book/api/member/oauth2/OAuthAttributes.java
@@ -1,5 +1,6 @@
 package com.core.book.api.member.oauth2;
 
+import com.core.book.api.member.entity.InfoOpen;
 import com.core.book.api.member.entity.Role;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,6 +41,7 @@ public class OAuthAttributes {
                 .nickname(oauth2UserInfo.getNickname())
                 .imageUrl(oauth2UserInfo.getImageUrl())
                 .role(Role.GUEST)
+                .marketing_allow(Boolean.FALSE)
                 .build();
     }
 }

--- a/src/main/java/com/core/book/api/member/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/core/book/api/member/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,22 @@
+package com.core.book.api.member.oauth2.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/core/book/api/member/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/core/book/api/member/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,58 @@
+package com.core.book.api.member.oauth2.handler;
+
+import com.core.book.api.member.entity.Role;
+import com.core.book.api.member.jwt.service.JwtService;
+import com.core.book.api.member.oauth2.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login 성공!");
+        try {
+            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+            if (oAuth2User.getRole() == Role.GUEST) {
+                handleGuestLogin(response, oAuth2User);
+            } else {
+                handleUserLogin(response, oAuth2User);
+            }
+        } catch (Exception e) {
+            log.error("OAuth2 로그인 처리 중 오류 발생: ", e);
+            response.sendRedirect("/login?error");
+        }
+    }
+
+    private void handleGuestLogin(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+        String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
+        jwtService.sendAccessToken(response, accessToken);
+        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        response.sendRedirect("https://www.google.com");
+    }
+
+    private void handleUserLogin(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+        String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
+        String refreshToken = jwtService.createRefreshToken();
+        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
+
+        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
+        response.sendRedirect("https://www.naver.com");
+    }
+}

--- a/src/main/java/com/core/book/api/member/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/core/book/api/member/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -41,8 +41,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private void handleGuestLogin(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
         String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
         jwtService.sendAccessToken(response, accessToken);
-        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
-        response.sendRedirect("https://www.google.com");
+        //response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        //response.sendRedirect("https://www.google.com");
+
+        String redirectUrl = "http://localhost:3000?accessToken=" + accessToken;
+        response.sendRedirect(redirectUrl);
     }
 
     private void handleUserLogin(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
@@ -51,8 +54,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
         jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
 
-        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
-        response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
-        response.sendRedirect("https://www.naver.com");
+        //response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        //response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
+        //response.sendRedirect("https://www.naver.com");
+
+        String redirectUrl = "http://localhost:3000?accessToken=" + accessToken + "&refreshToken=" + refreshToken;
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/com/core/book/api/member/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/core/book/api/member/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,39 @@
+package com.core.book.api.member.oauth2.userinfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (account == null || profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (account == null || profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("thumbnail_image_url");
+    }
+}

--- a/src/main/java/com/core/book/api/member/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/core/book/api/member/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,18 @@
+package com.core.book.api.member.oauth2.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getNickname();
+
+    public abstract String getImageUrl();
+}

--- a/src/main/java/com/core/book/api/member/repository/InfoOpenRepository.java
+++ b/src/main/java/com/core/book/api/member/repository/InfoOpenRepository.java
@@ -1,0 +1,7 @@
+package com.core.book.api.member.repository;
+
+import com.core.book.api.member.entity.InfoOpen;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InfoOpenRepository extends JpaRepository<InfoOpen, Long> {
+}

--- a/src/main/java/com/core/book/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/core/book/api/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.core.book.api.member.repository;
+
+import com.core.book.api.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
+
+    Optional<Member> findBySocialId(String socialId);
+}

--- a/src/main/java/com/core/book/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/core/book/api/member/repository/MemberRepository.java
@@ -9,8 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByNickname(String nickname);
-
     Optional<Member> findByRefreshToken(String refreshToken);
 
     Optional<Member> findBySocialId(String socialId);

--- a/src/main/java/com/core/book/api/member/repository/UserTagRepository.java
+++ b/src/main/java/com/core/book/api/member/repository/UserTagRepository.java
@@ -1,0 +1,13 @@
+package com.core.book.api.member.repository;
+
+import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.entity.UserTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserTagRepository extends JpaRepository<UserTag, Long> {
+
+    Optional<UserTag> findByMember(Member member);
+
+}

--- a/src/main/java/com/core/book/api/member/service/MemberService.java
+++ b/src/main/java/com/core/book/api/member/service/MemberService.java
@@ -1,9 +1,18 @@
 package com.core.book.api.member.service;
 
+import com.core.book.api.member.dto.UserTagRequestDTO;
+import com.core.book.api.member.entity.InfoOpen;
 import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.entity.UserTag;
+import com.core.book.api.member.jwt.service.JwtService;
+import com.core.book.api.member.repository.InfoOpenRepository;
 import com.core.book.api.member.repository.MemberRepository;
 import com.core.book.api.member.oauth2.CustomOAuth2User;
 import com.core.book.api.member.oauth2.OAuthAttributes;
+import com.core.book.api.member.repository.UserTagRepository;
+import com.core.book.common.exception.BadRequestException;
+import com.core.book.common.exception.NotFoundException;
+import com.core.book.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -13,7 +22,10 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.Map;
 
@@ -23,6 +35,9 @@ import java.util.Map;
 public class MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final MemberRepository memberRepository;
+    private final UserTagRepository userTagRepository;
+    private final InfoOpenRepository infoOpenRepository;
+    private final JwtService jwtService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -51,7 +66,7 @@ public class MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth
     private Member getUser(OAuthAttributes attributes) {
         Member findUser = memberRepository.findBySocialId(attributes.getOauth2UserInfo().getId()).orElse(null);
 
-        if(findUser == null) {
+        if (findUser == null) {
             return saveUser(attributes);
         }
         return findUser;
@@ -59,6 +74,100 @@ public class MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth
 
     private Member saveUser(OAuthAttributes attributes) {
         Member createdUser = attributes.toEntity(attributes.getOauth2UserInfo());
-        return memberRepository.save(createdUser);
+
+        // 초기 사용자 모든 정보 공개 TRUE 설정
+        InfoOpen infoOpen = InfoOpen.builder()
+                .follow_open(true)
+                .content_open(true)
+                .comment_open(true)
+                .like_open(true)
+                .member(createdUser)
+                .build();
+
+        Member savedMember = memberRepository.save(createdUser);
+
+        infoOpenRepository.save(infoOpen);
+
+        return savedMember;
+    }
+
+    @Transactional(readOnly = true)
+    public Member getMemberDetails(String email) {
+        // 해당 유저를 찾을 수 없을 경우 예외처리
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+    }
+
+    @Transactional
+    public void registerInitialTags(String email, UserTagRequestDTO userTagRequest, HttpServletResponse response) {
+        // 해당 유저를 찾을 수 없을 경우 예외처리
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 이미 사용자가 초기 유저 태그 등록을 했을 경우 예외처리
+        if (userTagRepository.findByMember(member).isPresent()) {
+            throw new BadRequestException(ErrorStatus.ALREADY_ADD_USERTAG_EXCEPTION.getMessage());
+        }
+
+        validateTagRequest(userTagRequest);
+
+        UserTag userTag = UserTag.builder()
+                .member(member)
+                .tag1(sanitizeTag(userTagRequest.getTag1()))
+                .tag2(sanitizeTag(userTagRequest.getTag2()))
+                .tag3(sanitizeTag(userTagRequest.getTag3()))
+                .tag4(sanitizeTag(userTagRequest.getTag4()))
+                .tag5(sanitizeTag(userTagRequest.getTag5()))
+                .build();
+
+        userTagRepository.save(userTag);
+
+        // 유저 권한 설정 GUEST -> USER
+        Member updatedMember = member.authorizeUser();
+        memberRepository.save(updatedMember);
+
+        // 엑세스 토큰 및 리프레시 토큰 발급 후 쿠키로 전송
+        String accessToken = jwtService.createAccessToken(member.getEmail());
+        String refreshToken = jwtService.createRefreshToken();
+
+        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+
+        // 리프레시 토큰 업데이트
+        jwtService.updateRefreshToken(member.getEmail(), refreshToken);
+    }
+
+    private void validateTagRequest(UserTagRequestDTO userTagRequest) {
+        if (isAllTagsEmpty(userTagRequest)) {
+            throw new BadRequestException(ErrorStatus.USERTAG_REQUEST_MISSING_EXCEPTION.getMessage());
+        }
+    }
+
+    private boolean isAllTagsEmpty(UserTagRequestDTO userTagRequest) {
+        return !StringUtils.hasText(userTagRequest.getTag1()) &&
+                !StringUtils.hasText(userTagRequest.getTag2()) &&
+                !StringUtils.hasText(userTagRequest.getTag3()) &&
+                !StringUtils.hasText(userTagRequest.getTag4()) &&
+                !StringUtils.hasText(userTagRequest.getTag5());
+    }
+
+    private String sanitizeTag(String tag) {
+        return StringUtils.hasText(tag) ? tag : null;
+    }
+
+    @Transactional
+    public void registerInitialMarketing(String email, String approve) {
+        // 해당 유저를 찾을 수 없을 경우 예외처리
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // OK 일 경우 마케팅 동의 여부 TRUE 변경, 그 외는 FALSE
+        Member updatedMember;
+        if ("ok".equalsIgnoreCase(approve)) {
+            updatedMember = member.updateMarketingAllow(true);
+        } else {
+            updatedMember = member.updateMarketingAllow(false);
+        }
+
+        memberRepository.save(updatedMember);
     }
 }

--- a/src/main/java/com/core/book/api/member/service/MemberService.java
+++ b/src/main/java/com/core/book/api/member/service/MemberService.java
@@ -1,0 +1,64 @@
+package com.core.book.api.member.service;
+
+import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.repository.MemberRepository;
+import com.core.book.api.member.oauth2.CustomOAuth2User;
+import com.core.book.api.member.oauth2.OAuthAttributes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        OAuthAttributes extractAttributes = OAuthAttributes.of(userNameAttributeName, attributes);
+
+        Member createdUser = getUser(extractAttributes);
+
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdUser.getRole().getKey())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdUser.getEmail(),
+                createdUser.getRole()
+        );
+    }
+
+    private Member getUser(OAuthAttributes attributes) {
+        Member findUser = memberRepository.findBySocialId(attributes.getOauth2UserInfo().getId()).orElse(null);
+
+        if(findUser == null) {
+            return saveUser(attributes);
+        }
+        return findUser;
+    }
+
+    private Member saveUser(OAuthAttributes attributes) {
+        Member createdUser = attributes.toEntity(attributes.getOauth2UserInfo());
+        return memberRepository.save(createdUser);
+    }
+}

--- a/src/main/java/com/core/book/common/config/SecurityConfig.java
+++ b/src/main/java/com/core/book/common/config/SecurityConfig.java
@@ -1,0 +1,69 @@
+package com.core.book.common.config;
+
+import com.core.book.common.config.jwt.JwtConfig;
+import com.core.book.common.config.oauth2.OAuth2Config;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtConfig jwtConfig;
+    private final OAuth2Config oAuth2Config;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .formLogin(form -> form.disable()) // FormLogin 사용 X
+                .httpBasic(basic -> basic.disable()) // httpBasic 사용 X
+                .csrf(csrf -> csrf.disable()) // csrf 보안 사용 X
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers( "/health","/v3/api-docs/**", "/swagger-resources/**","/swagger-ui/**", "/h2-console/**").permitAll()
+
+                        .requestMatchers("/oauth2/authorization/kakao").permitAll() // 카카오 로그인 접근 가능
+                        .anyRequest().authenticated() // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능
+                )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)) // 401 Unauthorized 반환
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .loginPage("/oauth2/authorization/kakao")
+                        .successHandler(oAuth2Config.getOAuth2LoginSuccessHandler()) // 동의하고 계속하기를 눌렀을 때 Handler 설정
+                        .failureHandler(oAuth2Config.getOAuth2LoginFailureHandler()) // 소셜 로그인 실패 시 핸들러 설정
+                        .clientRegistrationRepository(oAuth2Config.clientRegistrationRepository())
+                        .authorizedClientService(oAuth2Config.authorizedClientService())
+                        .tokenEndpoint(token -> token.accessTokenResponseClient(oAuth2Config.authorizationCodeTokenResponseClient()))
+                        .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2Config.getCustomOAuth2UserService())) // customUserService 설정
+                );
+
+        // JwtAuthenticationProcessingFilter를 추가하여 JWT 인증을 처리
+        http.addFilterBefore(jwtConfig.jwtAuthenticationProcessingFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    /**
+     * AuthenticationManager 설정 후 등록
+     * FormLogin(기존 스프링 시큐리티 로그인)과 동일하게 DaoAuthenticationProvider 사용
+     */
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        return new ProviderManager(provider);
+    }
+}

--- a/src/main/java/com/core/book/common/config/SecurityConfig.java
+++ b/src/main/java/com/core/book/common/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers( "/health","/v3/api-docs/**", "/swagger-resources/**","/swagger-ui/**", "/h2-console/**").permitAll()
+                        .requestMatchers( "/api-doc", "/health","/v3/api-docs/**", "/swagger-resources/**","/swagger-ui/**", "/h2-console/**").permitAll()
 
                         .requestMatchers("/oauth2/authorization/kakao").permitAll() // 카카오 로그인 접근 가능
                         .anyRequest().authenticated() // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능

--- a/src/main/java/com/core/book/common/config/jwt/JwtConfig.java
+++ b/src/main/java/com/core/book/common/config/jwt/JwtConfig.java
@@ -1,0 +1,21 @@
+package com.core.book.common.config.jwt;
+
+import com.core.book.api.member.jwt.filter.JwtAuthenticationProcessingFilter;
+import com.core.book.api.member.jwt.service.JwtService;
+import com.core.book.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtConfig {
+
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+    @Bean
+    public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
+        return new JwtAuthenticationProcessingFilter(jwtService, memberRepository);
+    }
+}

--- a/src/main/java/com/core/book/common/config/oauth2/OAuth2Config.java
+++ b/src/main/java/com/core/book/common/config/oauth2/OAuth2Config.java
@@ -1,0 +1,111 @@
+package com.core.book.common.config.oauth2;
+
+import com.core.book.api.member.oauth2.handler.OAuth2LoginFailureHandler;
+import com.core.book.api.member.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.core.book.api.member.service.MemberService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.RequestEntity;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequestEntityConverter;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+
+@Configuration
+@RequiredArgsConstructor
+@Getter
+public class OAuth2Config {
+
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final MemberService customOAuth2UserService;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-authentication-method}")
+    private String clientAuthenticationMethod;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
+    private String authorizationGrantType;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.scope}")
+    private String scope;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+    private String authorizationUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-name-attribute}")
+    private String userNameAttributeName;
+
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+        return new InMemoryClientRegistrationRepository(this.kakaoClientRegistration());
+    }
+
+    private ClientRegistration kakaoClientRegistration() {
+        return ClientRegistration.withRegistrationId("kakao")
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(new org.springframework.security.oauth2.core.AuthorizationGrantType(authorizationGrantType))
+                .redirectUri(redirectUri)
+                .scope(scope.trim().split("\\s*,\\s*"))
+                .authorizationUri(authorizationUri)
+                .tokenUri(tokenUri)
+                .userInfoUri(userInfoUri)
+                .userNameAttributeName(userNameAttributeName)
+                .clientName("Kakao")
+                .build();
+    }
+
+    @Bean
+    public OAuth2AuthorizedClientService authorizedClientService() {
+        return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository());
+    }
+
+    @Bean
+    public DefaultAuthorizationCodeTokenResponseClient authorizationCodeTokenResponseClient() {
+        DefaultAuthorizationCodeTokenResponseClient client = new DefaultAuthorizationCodeTokenResponseClient();
+        client.setRequestEntityConverter(new CustomOAuth2AuthorizationRequestEntityConverter());
+        return client;
+    }
+
+    // CustomOAuth2AuthorizationRequestEntityConverter 클래스 추가
+    public class CustomOAuth2AuthorizationRequestEntityConverter extends OAuth2AuthorizationCodeGrantRequestEntityConverter {
+
+        @Override
+        public RequestEntity<?> convert(OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest) {
+            RequestEntity<?> requestEntity = super.convert(authorizationCodeGrantRequest);
+
+            if (authorizationCodeGrantRequest.getClientRegistration().getClientAuthenticationMethod() == ClientAuthenticationMethod.CLIENT_SECRET_POST) {
+                return RequestEntity
+                        .post(requestEntity.getUrl())
+                        .headers(requestEntity.getHeaders())
+                        .body(requestEntity.getBody());
+            }
+
+            return requestEntity;
+        }
+    }
+}

--- a/src/main/java/com/core/book/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/core/book/common/config/swagger/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.core.book.common.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearer-key");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("코어 프로젝트 API")
+                        .description("독서 커뮤니티 REST API Document- Backend Developer : 태근, 주현")
+                        .version("1.0.0"))
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key", securityScheme))
+                .addSecurityItem(securityRequirement);
+    }
+}

--- a/src/main/java/com/core/book/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/core/book/common/entity/BaseTimeEntity.java
@@ -1,5 +1,6 @@
 package com.core.book.common.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
+    @Column(updatable = false)
     protected LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/com/core/book/common/exception/BadRequestException.java
+++ b/src/main/java/com/core/book/common/exception/BadRequestException.java
@@ -1,0 +1,13 @@
+package com.core.book.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BaseException{
+    public BadRequestException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+
+    public BadRequestException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/com/core/book/common/exception/NotFoundException.java
+++ b/src/main/java/com/core/book/common/exception/NotFoundException.java
@@ -1,0 +1,13 @@
+package com.core.book.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends BaseException{
+    public NotFoundException() {
+        super(HttpStatus.NOT_FOUND);
+    }
+
+    public NotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/core/book/common/response/ApiResponse.java
+++ b/src/main/java/com/core/book/common/response/ApiResponse.java
@@ -14,8 +14,8 @@ public class ApiResponse<T> {
     private final String message;
     private T data;
 
-    public static ApiResponse success(SuccessStatus status, Object data) {
-        return ApiResponse.builder()
+    public static <T> ApiResponse<T> success(SuccessStatus status, T data) {
+        return ApiResponse.<T>builder()
                 .status(status.getStatusCode())
                 .success(true)
                 .message(status.getMessage())
@@ -23,16 +23,16 @@ public class ApiResponse<T> {
                 .build();
     }
 
-    public static ApiResponse success(int status, String message) {
-        return ApiResponse.builder()
-                .status(status)
+    public static ApiResponse<Void> success_only(SuccessStatus status) {
+        return ApiResponse.<Void>builder()
+                .status(status.getStatusCode())
                 .success(true)
-                .message(message)
+                .message(status.getMessage())
                 .build();
     }
 
-    public static ApiResponse fail(int status, String message) {
-        return ApiResponse.builder()
+    public static ApiResponse<Void> fail(int status, String message) {
+        return ApiResponse.<Void>builder()
                 .status(status)
                 .success(false)
                 .message(message)

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -13,6 +13,8 @@ public enum ErrorStatus {
      * 400 BAD_REQUEST
      */
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
+    USERTAG_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "최소 한개 이상의 USERTAG가 발송되지 않았습니다."),
+    ALREADY_ADD_USERTAG_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 유저는 이미 태그가 등록되었습니다."),
 
     /**
      * 404 NOT_FOUND

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -18,6 +18,8 @@ public enum ErrorStatus {
      * 404 NOT_FOUND
      */
 
+    USER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+
     /**
      * 500 SERVER_ERROR
      */

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -13,10 +13,13 @@ public enum SuccessStatus {
      * 200
      */
     SEND_USERDETAIL_SUCCESS(HttpStatus.OK, "유저 정보 발송 성공"),
+    SET_USER_MARKETING_SUCCESS(HttpStatus.OK, "유저 마케팅 동의 여부 설정 성공"),
 
     /**
      * 201
      */
+    CREATE_ARTICLE_SUCCESS(HttpStatus.CREATED, "게시판 등록 성공"),
+    CREATE_USERTAG_SUCCESS(HttpStatus.CREATED, "USERTAG 등록 성공")
 
     ;
 

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -12,7 +12,7 @@ public enum SuccessStatus {
     /**
      * 200
      */
-    SEND_QUESTION_SUCCESS(HttpStatus.OK, "문제 발송 성공"),
+    SEND_USERDETAIL_SUCCESS(HttpStatus.OK, "유저 정보 발송 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #18 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 처음 접속한 사용자 추가 설정(마케팅 정보 동의 여부, 선호하는 책 취향 태그, 정보 공개 여부) 등록 기능을 구현하였습니다.
- 태그 등록 엔드포인트 :  POST {URL}/api/v1/member/initial-tags

[ 태그 등록 POST Request 형식]
{
    "tag1" : "",
    "tag2" : "",
    "tag3" : "",
    "tag4" : "",
    "tag5" : ""
}

- 마케팅 정보 동의 엔드포인트 : GET {URL}/api/v1/member/initial-marketing?approve={ok/no}

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- Member 엔티티 내 Builder 패턴으로 코드 리팩토링 하였습니다.
- accessToken, refreshToken 전달 방식을 헤더에서 Cookie 방식으로 변경하였습니다.
- ApiResponse 클래스 사용시 발생한 제너릭 경고를 해결하였습니다.
- 사용자의 Role이 User로 승격될 때 accessToken, refreshToken 토큰이 발급되도록 코드 수정하였습니다.
- 처음 회원가입한 사용자의 정보공개 초기값이 TRUE로 되도록 설정하였습니다.
- 정보수정시 BaseTimeEntity 내 createAt가 null로 초기화 되는 문제를 해결하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/74f0e3d0-7b64-407d-bb85-84dd53b7b9ab)
![image](https://github.com/user-attachments/assets/1e475b93-3ded-408a-9f65-7ce61e445b41)
![image](https://github.com/user-attachments/assets/a7d4900a-45e8-4734-9b00-3fbf52c41f7a)
![image](https://github.com/user-attachments/assets/d0db3890-0b6e-4296-b99e-3d8d04882d80)
![image](https://github.com/user-attachments/assets/ac51ea32-7e5c-46e9-a276-c598a21389e1)


