### PR TITLE
[FEAT] 회원 정보 수정(프로필사진, 닉네임, 정보공개, 탈퇴) 및 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,14 +28,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+	//AWS S3
+	implementation 'software.amazon.awssdk:s3:2.27.12'
+
 	//Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 	//SpringSecurity
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	//JWT
-	implementation 'com.auth0:java-jwt:4.2.1'
+	implementation 'com.auth0:java-jwt:4.4.0'
 
 	//OAuth
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -47,7 +50,7 @@ dependencies {
 	//runtimeOnly 'com.h2database:h2'
 
 	// MYSQL
-	implementation 'mysql:mysql-connector-java:8.0.32'
+	implementation 'mysql:mysql-connector-java:8.0.33'
 
 	//Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -1,21 +1,29 @@
 package com.core.book.api.member.controller;
 
+import com.core.book.api.member.dto.InfoOpenRequestDTO;
+import com.core.book.api.member.dto.UserInfoResponseDTO;
 import com.core.book.api.member.dto.UserTagRequestDTO;
-import com.core.book.api.member.entity.Member;
 import com.core.book.api.member.service.MemberService;
+import com.core.book.common.exception.BadRequestException;
+import com.core.book.common.exception.InternalServerException;
 import com.core.book.common.response.ApiResponse;
+import com.core.book.common.response.ErrorStatus;
 import com.core.book.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @Tag(name = "Member", description = "Member 관련 API 입니다.")
 @RestController
@@ -25,13 +33,18 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    // 사용자 토큰 인증 확인용 임시 API 입니다.
     @Operation(
-            summary = "[임시]")
-    @GetMapping("/check")
-    public ApiResponse<Member> getMemberDetails(@AuthenticationPrincipal UserDetails userDetails) {
-        Member member = memberService.getMemberDetails(userDetails.getUsername());
-        return ApiResponse.success(SuccessStatus.SEND_USERDETAIL_SUCCESS, member);
+            summary = "사용자 정보 조회 API",
+            description = "토큰을 통해 인증된 사용자의 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
+    })
+    @GetMapping("/user-info")
+    public ResponseEntity<ApiResponse<UserInfoResponseDTO>> getUserInfo(@AuthenticationPrincipal UserDetails userDetails) {
+        UserInfoResponseDTO userInfo = memberService.getUserInfo(userDetails.getUsername());
+        return ApiResponse.success(SuccessStatus.GET_USERINFO_SUCCESS, userInfo);
     }
 
     // 최초 회원가입 사용자 유저 태그 등록 API
@@ -44,29 +57,124 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "최소 한개 이상의 USERTAG가 발송되지 않았습니다.")
     })
     @PostMapping("/initial-tags")
-    public ApiResponse<Void> registerInitialTags(@AuthenticationPrincipal UserDetails userDetails, @RequestBody UserTagRequestDTO userTagRequest, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> registerInitialTags(@AuthenticationPrincipal UserDetails userDetails, @RequestBody UserTagRequestDTO userTagRequest, HttpServletResponse response) {
+
+        // 사용자 태그가 입력되지 않았을 경우 예외 처리
+        if (userTagRequest == null) {
+            throw new BadRequestException(ErrorStatus.MISSING_USERTAG.getMessage());
+        }
 
         memberService.registerInitialTags(userDetails.getUsername(), userTagRequest, response);
         return ApiResponse.success_only(SuccessStatus.CREATE_USERTAG_SUCCESS);
     }
 
-    // 최초 회원가입 사용자 마케팅 동의 여부 등록 API (approve = ok : 승인 / approve = no : 미승인)
+    // 최초 회원가입 사용자 마케팅 동의 여부 등록 API
     @Operation(
             summary = "처음 사용자용 마케팅 정보 동의 등록 API",
             description = "처음 사용자 추가 정보 등록페이지 에서 마케팅 동의 여부를 확인 후 동의 여부 등록합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 마케팅 동의 여부 설정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "사용자의 마케팅 동의 정보가 입력되지 않았습니다."),
     })
     @GetMapping("/initial-marketing")
-    public ApiResponse<Void> registerInitialMarketing(@AuthenticationPrincipal UserDetails userDetails,
+    public ResponseEntity<ApiResponse<Void>> registerInitialMarketing(@AuthenticationPrincipal UserDetails userDetails,
                                                       @Parameter(
                                                               description = "사용자의 마케팅 동의 여부를 나타내는 파라미터로, 'ok'는 승인, 'no'는 미승인을 의미합니다.",
                                                               example = "ok",
                                                               in = ParameterIn.QUERY)
                                                       @RequestParam String approve) {
 
+        // 마케팅 동의 정보가 입력되지 않았을 경우 예외 처리
+        if (approve == null || approve.isEmpty()) {
+            throw new BadRequestException(ErrorStatus.MISSING_MARKETING_APPROVE.getMessage());
+        }
+
         memberService.registerInitialMarketing(userDetails.getUsername(), approve);
         return ApiResponse.success_only(SuccessStatus.SET_USER_MARKETING_SUCCESS);
     }
+
+    // 프로필 사진 변경 API
+    @Operation(
+            summary = "프로필 사진 변경 API",
+            description = "사용자의 프로필 사진을 변경합니다. with MultipartFile"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 사진 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "수정할 프로필 이미지파일이 업로드 되지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "프로팔 사진이 변경되지 않았습니다.")
+    })
+    @PutMapping(value = "/change-profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> changeProfileImage(@AuthenticationPrincipal UserDetails userDetails,
+                                                @RequestParam("image") MultipartFile image) {
+        // 이미지가 첨부되지 않았을 경우 예외 처리
+        if (image == null || image.isEmpty()) {
+            throw new BadRequestException(ErrorStatus.MISSING_UPLOAD_IMAGE.getMessage());
+        }
+
+        try {
+            // 이미지 업로드 및 프로필 이미지 업데이트
+            memberService.updateProfileImage(userDetails.getUsername(), image);
+            return ApiResponse.success_only(SuccessStatus.UPDATE_PROFILE_IMAGE_SUCCESS);
+        } catch (IOException e) {
+            throw new InternalServerException(ErrorStatus.FAIL_UPLOAD_PROFILE_IMAGE.getMessage());
+        }
+    }
+
+    // 닉네임 변경 API
+    @Operation(
+            summary = "닉네임 변경 API",
+            description = "사용자의 닉네임을 변경합니다. (닉네임 필터 조건 : 닉네임은 10자 이하로 설정, 닉네임은 영문, 숫자, 한글만 사용가능, 현재 다른 사용자가 사용중인 닉네임은 사용 불가)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "닉네임이 입력되지 않았습니다."),
+    })
+    @PutMapping("/change-nickname")
+    public ResponseEntity<ApiResponse<Void>> changeNickname(@AuthenticationPrincipal UserDetails userDetails,
+                                            @RequestParam("nickname") String nickname) {
+        // 닉네임이 입력되지 않았을 경우 예외 처리
+        if (nickname == null || nickname.isEmpty()) {
+            throw new BadRequestException(ErrorStatus.MISSING_NICKNAME.getMessage());
+        }
+
+        memberService.changeNickname(userDetails.getUsername(), nickname);
+        return ApiResponse.success_only(SuccessStatus.UPDATE_NICKNAME_SUCCESS);
+    }
+
+    // 정보 공개 여부 변경 API
+    @Operation(
+            summary = "정보 공개 여부 수정 API",
+            description = "사용자의 정보 공개 여부를 수정합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "정보 공개 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "정보 공개 여부 값이 입력되지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
+    })
+    @PutMapping("/change-info-open")
+    public ResponseEntity<ApiResponse<Void>> changeInfoOpen(@AuthenticationPrincipal UserDetails userDetails,
+                                            @RequestBody InfoOpenRequestDTO infoOpenRequestDTO) {
+        // 정보 공개 여부 값이 입력되지 않았을 경우 예외 처리
+        if (infoOpenRequestDTO == null) {
+            throw new BadRequestException(ErrorStatus.MISSING_INFOOPEN.getMessage());
+        }
+
+        memberService.updateInfoOpen(userDetails.getUsername(), infoOpenRequestDTO);
+        return ApiResponse.success_only(SuccessStatus.UPDATE_INFO_OPEN_SUCCESS);
+    }
+
+    // 회원 탈퇴 API
+    @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴 시 연관된 모든 데이터를 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
+    })
+    @DeleteMapping("/quit")
+    public ResponseEntity<ApiResponse<Void>> quitMember(@AuthenticationPrincipal UserDetails userDetails) {
+
+        memberService.quitMember(userDetails.getUsername());
+        return ApiResponse.success_only(SuccessStatus.DELETE_MEMBER_SUCCESS);
+    }
+
 }

--- a/src/main/java/com/core/book/api/member/dto/InfoOpenRequestDTO.java
+++ b/src/main/java/com/core/book/api/member/dto/InfoOpenRequestDTO.java
@@ -1,0 +1,13 @@
+package com.core.book.api.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InfoOpenRequestDTO {
+    private Boolean follow_open;
+    private Boolean content_open;
+    private Boolean comment_open;
+    private Boolean like_open;
+}

--- a/src/main/java/com/core/book/api/member/dto/UserInfoResponseDTO.java
+++ b/src/main/java/com/core/book/api/member/dto/UserInfoResponseDTO.java
@@ -1,0 +1,57 @@
+package com.core.book.api.member.dto;
+
+import com.core.book.api.member.entity.InfoOpen;
+import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.entity.UserTag;
+import lombok.Getter;
+
+@Getter
+public class UserInfoResponseDTO {
+    private final Long id;
+    private final String nickname;
+    private final String imageUrl;
+    private final Boolean marketingAllow;
+    private final UserTagDTO userTag;
+    private final InfoOpenDTO infoOpen;
+
+    public UserInfoResponseDTO(Member member, UserTag userTag, InfoOpen infoOpen) {
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+        this.imageUrl = member.getImageUrl();
+        this.marketingAllow = member.getMarketing_allow();
+        this.userTag = userTag != null ? new UserTagDTO(userTag) : null;
+        this.infoOpen = infoOpen != null ? new InfoOpenDTO(infoOpen) : null;
+    }
+
+    @Getter
+    public static class UserTagDTO {
+        private final String tag1;
+        private final String tag2;
+        private final String tag3;
+        private final String tag4;
+        private final String tag5;
+
+        public UserTagDTO(UserTag userTag) {
+            this.tag1 = userTag.getTag1();
+            this.tag2 = userTag.getTag2();
+            this.tag3 = userTag.getTag3();
+            this.tag4 = userTag.getTag4();
+            this.tag5 = userTag.getTag5();
+        }
+    }
+
+    @Getter
+    public static class InfoOpenDTO {
+        private final Boolean followOpen;
+        private final Boolean contentOpen;
+        private final Boolean commentOpen;
+        private final Boolean likeOpen;
+
+        public InfoOpenDTO(InfoOpen infoOpen) {
+            this.followOpen = infoOpen.getFollow_open();
+            this.contentOpen = infoOpen.getContent_open();
+            this.commentOpen = infoOpen.getComment_open();
+            this.likeOpen = infoOpen.getLike_open();
+        }
+    }
+}

--- a/src/main/java/com/core/book/api/member/entity/InfoOpen.java
+++ b/src/main/java/com/core/book/api/member/entity/InfoOpen.java
@@ -10,7 +10,6 @@ import lombok.*;
 @Builder(toBuilder = true)
 @Table(name = "INFO_OPEN")
 @AllArgsConstructor
-
 public class InfoOpen extends BaseTimeEntity {
 
     @Id
@@ -26,5 +25,14 @@ public class InfoOpen extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private Member member;
+
+    public InfoOpen updateInfoOpen(Boolean followOpen, Boolean contentOpen, Boolean commentOpen, Boolean likeOpen) {
+        return this.toBuilder()
+                .follow_open(followOpen)
+                .content_open(contentOpen)
+                .comment_open(commentOpen)
+                .like_open(likeOpen)
+                .build();
+    }
 
 }

--- a/src/main/java/com/core/book/api/member/entity/Member.java
+++ b/src/main/java/com/core/book/api/member/entity/Member.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import jakarta.persistence.*;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,10 +35,11 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     private String refreshToken; // 리프레시 토큰
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
-    private UserTag userTag;
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
-    private InfoOpen infoOpen;
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> following;  // 내가 팔로우 하는 사람들
+
+    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followers;  // 나를 팔로우 하는 사람들
 
     // 유저 권한 설정 메소드
     public Member authorizeUser() {
@@ -57,6 +59,13 @@ public class Member extends BaseTimeEntity implements UserDetails {
     public Member updateRefreshToken(String updateRefreshToken) {
         return this.toBuilder()
                 .refreshToken(updateRefreshToken)
+                .build();
+    }
+
+    // 프로필이미지 필드 업데이트
+    public Member updateImageUrl(String updateImageUrl) {
+        return this.toBuilder()
+                .imageUrl(updateImageUrl)
                 .build();
     }
 

--- a/src/main/java/com/core/book/api/member/jwt/service/JwtService.java
+++ b/src/main/java/com/core/book/api/member/jwt/service/JwtService.java
@@ -117,10 +117,8 @@ public class JwtService {
     @Transactional
     public void updateRefreshToken(String email, String refreshToken) {
         memberRepository.findByEmail(email).ifPresent(member -> {
-            Member updatedMember = member.toBuilder()
-                    .refreshToken(refreshToken)
-                    .build();
-            memberRepository.save(updatedMember); // 새로 생성된 객체를 저장
+            Member updatedMember = member.updateRefreshToken(refreshToken);
+            memberRepository.save(updatedMember);
         });
     }
 

--- a/src/main/java/com/core/book/api/member/repository/InfoOpenRepository.java
+++ b/src/main/java/com/core/book/api/member/repository/InfoOpenRepository.java
@@ -1,7 +1,12 @@
 package com.core.book.api.member.repository;
 
 import com.core.book.api.member.entity.InfoOpen;
+import com.core.book.api.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface InfoOpenRepository extends JpaRepository<InfoOpen, Long> {
+
+    Optional<InfoOpen> findByMember(Member member);
 }

--- a/src/main/java/com/core/book/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/core/book/api/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByRefreshToken(String refreshToken);
 
     Optional<Member> findBySocialId(String socialId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/core/book/api/member/service/S3Service.java
+++ b/src/main/java/com/core/book/api/member/service/S3Service.java
@@ -1,0 +1,68 @@
+package com.core.book.api.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.core.sync.RequestBody;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    public String uploadFile(String email, MultipartFile file) throws IOException {
+        String dir = "profile-images";
+        String defaultUrl = "https://moongeul.s3.ap-northeast-2.amazonaws.com";
+
+        // 현재 날짜와 시간 가져오기
+        String currentDateTime = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss").format(new Date());
+
+        // 파일 확장자 추출
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+
+        // 이메일 + 현재날짜 + 현재시간 + 확장자 형식으로 파일 이름 설정
+        String fileName = email + "_" + currentDateTime + extension;
+        String fileKey = dir + "/" + fileName;
+
+        // 파일 업로드 시 퍼블릭 읽기 권한을 추가
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .acl("public-read")
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+        return defaultUrl + "/" + fileKey;
+    }
+
+    public void deleteFile(String imageUrl) {
+        // 만약 사용자의 image_url이 "https://moongeul.s3" 로 시작한다면 해당 이미지를 버킷에서 삭제
+        if (imageUrl != null && imageUrl.startsWith("https://moongeul.s3")) {
+            String fileKey = imageUrl.replace("https://moongeul.s3.ap-northeast-2.amazonaws.com/", "");
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileKey)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        }
+    }
+}

--- a/src/main/java/com/core/book/common/config/aws/S3Config.java
+++ b/src/main/java/com/core/book/common/config/aws/S3Config.java
@@ -1,0 +1,31 @@
+package com.core.book.common.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/core/book/common/exception/InternalServerException.java
+++ b/src/main/java/com/core/book/common/exception/InternalServerException.java
@@ -1,0 +1,13 @@
+package com.core.book.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InternalServerException extends BaseException{
+    public InternalServerException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    public InternalServerException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message);
+    }
+}

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -15,6 +15,15 @@ public enum ErrorStatus {
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
     USERTAG_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "최소 한개 이상의 USERTAG가 발송되지 않았습니다."),
     ALREADY_ADD_USERTAG_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 유저는 이미 태그가 등록되었습니다."),
+    MISSING_UPLOAD_IMAGE(HttpStatus.BAD_REQUEST, "수정할 프로필 이미지파일이 업로드 되지 않았습니다."),
+    MISSING_NICKNAME(HttpStatus.BAD_REQUEST,"닉네임이 입력되지 않았습니다."),
+    MISSING_USERTAG(HttpStatus.BAD_REQUEST,"사용자 태그가 입력되지 않았습니다."),
+    MISSING_MARKETING_APPROVE(HttpStatus.BAD_REQUEST, "사용자의 마케팅 동의 정보가 입력되지 않았습니다."),
+    NOT_ALLOW_NICKNAME_FILTER_UNDER_10(HttpStatus.BAD_REQUEST, "닉네임은 10자 이하로 설정해야 합니다."),
+    NOT_ALLOW_USERTAG_FILTER_ROLE(HttpStatus.BAD_REQUEST, "닉네임은 영문, 숫자, 한글만 사용할 수 있습니다."),
+    NOT_ALLOW_USERTAG_FILTER_LIST(HttpStatus.BAD_REQUEST, "부적절한 닉네임입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST,"중복된 닉네임입니다."),
+    MISSING_INFOOPEN(HttpStatus.BAD_REQUEST,"정보 공개 여부 값이 입력되지 않았습니다."),
 
     /**
      * 404 NOT_FOUND
@@ -25,6 +34,8 @@ public enum ErrorStatus {
     /**
      * 500 SERVER_ERROR
      */
+
+    FAIL_UPLOAD_PROFILE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "프로팔 사진이 변경되지 않았습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -18,6 +18,14 @@ public enum SuccessStatus {
     SEND_QUESTION_SUCCESS(HttpStatus.OK, "문제 발송 성공"),
     BOOK_SEARCH_SUCCESS(HttpStatus.OK, "책 결과 반환 성공"),
 
+    UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 사진 변경 성공"),
+    UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경 성공"),
+    UPDATE_INFO_OPEN_SUCCESS(HttpStatus.OK,"정보 공개 수정 성공"),
+    DELETE_MEMBER_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공"),
+    GET_USERINFO_SUCCESS(HttpStatus.OK,"사용자 정보 조회 성공"),
+    USER_FOLLOW_SUCCESS(HttpStatus.OK,"팔로우 성공"),
+    USER_UNFOLLOW_SUCCESS(HttpStatus.OK,"언팔로우 성공"),
+
     /**
      * 201
      */


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #31 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 회원 정보 수정(프로필사진, 닉네임, 정보공개, 탈퇴) 기능 및 사용자의 정보를 조회 할 수 있는 기능을 구현하였습니다.
- Member 와 UserTag 및 UserInfo 를 순환참조 오류를 해결하기 위해 양방향에서 단방향으로 수정하였습니다.
- Build.grade 에서 의존성 모두 최신버전으로 업데이트 하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/50cd1dee-ce81-40b6-9112-4b6c7e621e9a">
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/f1147b69-c9d7-4a9a-b143-496b324ef5fb">
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/3164bdde-3942-452c-ad11-7c0ec09e566f">
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/e8054f07-1c51-4326-af8e-c19a8feb8292">
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/14198f1f-f2a5-488a-9f50-dac79f9da45a">
