### PR TITLE
[FEAT] 도서 검색 결과 페이징 처리 기능 구현

### DIFF
--- a/src/main/java/com/core/book/api/book/controller/BookController.java
+++ b/src/main/java/com/core/book/api/book/controller/BookController.java
@@ -1,6 +1,5 @@
 package com.core.book.api.book.controller;
 
-import com.core.book.api.book.entity.Book;
 import com.core.book.api.book.service.BookService;
 import com.core.book.common.exception.BadRequestException;
 import com.core.book.common.response.ApiResponse;
@@ -15,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @Slf4j
 @Tag(name = "Book", description = "Book 관련 API 입니다.")
@@ -33,14 +34,20 @@ public class BookController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값에 대한 반환 결과가 없습니다.")
     })
     @GetMapping("/api/v1/book")
-    public ResponseEntity<ApiResponse<Iterable<Book>>> book(@RequestParam("title") String text) {
-        log.info("Received text: {}", text);
+    public ResponseEntity<ApiResponse<Map<String, Object>>> book(
+            @RequestParam("title") String text,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+
+        log.info("Received text: {}, page: {}, size: {}", text, page, size);
+
         //예외처리 - 검색어가 입력되지 않았을 경우
         if(text.isEmpty()) {
             throw new BadRequestException(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage());
         }
 
-        Iterable<Book> book = bookService.book(text);
-        return ApiResponse.success(SuccessStatus.BOOK_SEARCH_SUCCESS, book);
+        Map<String, Object> responseMap = bookService.book(text, page, size);
+
+        return ApiResponse.success(SuccessStatus.BOOK_SEARCH_SUCCESS, responseMap);
     }
 }

--- a/src/main/java/com/core/book/api/book/controller/BookController.java
+++ b/src/main/java/com/core/book/api/book/controller/BookController.java
@@ -2,6 +2,7 @@ package com.core.book.api.book.controller;
 
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.book.service.BookService;
+import com.core.book.common.exception.BadRequestException;
 import com.core.book.common.response.ApiResponse;
 import com.core.book.common.response.ErrorStatus;
 import com.core.book.common.response.SuccessStatus;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,14 +33,14 @@ public class BookController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값에 대한 반환 결과가 없습니다.")
     })
     @GetMapping("/api/v1/book")
-    public ApiResponse<Iterable<Book>> book(@RequestParam("title") String text) {
+    public ResponseEntity<ApiResponse<Iterable<Book>>> book(@RequestParam("title") String text) {
         log.info("Received text: {}", text);
-        if(text.isEmpty()){
-            ApiResponse.fail(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getStatusCode(), ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage());
+        //예외처리 - 검색어가 입력되지 않았을 경우
+        if(text.isEmpty()) {
+            throw new BadRequestException(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage());
         }
 
         Iterable<Book> book = bookService.book(text);
-
         return ApiResponse.success(SuccessStatus.BOOK_SEARCH_SUCCESS, book);
     }
 }

--- a/src/main/java/com/core/book/api/book/controller/BookController.java
+++ b/src/main/java/com/core/book/api/book/controller/BookController.java
@@ -23,12 +23,12 @@ public class BookController {
     private BookService bookService;
 
     @Operation(
-            summary = "처음 사용자용 마케팅 정보 동의 등록 API",
-            description = "처음 사용자 추가 정보 등록페이지 에서 마케팅 동의 여부를 확인 후 동의 여부 등록합니다."
+            summary = "도서 데이터 요청 및 저장 API",
+            description = "도서 데이터를 외부 API에 요청해 가져오고 이를 DB에 저장합니다."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "책 결과 반환 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "최소 한개 이상의 USERTAG가 발송되지 않았습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "책 결과 반환 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값에 대한 반환 결과가 없습니다.")
     })
     @GetMapping("/api/v1/book")
     public ApiResponse<Iterable<Book>> book(@RequestParam("title") String text) {

--- a/src/main/java/com/core/book/api/book/dto/BookDto.java
+++ b/src/main/java/com/core/book/api/book/dto/BookDto.java
@@ -1,6 +1,7 @@
 package com.core.book.api.book.dto;
 
 import com.core.book.api.book.entity.Book;
+import com.core.book.api.book.entity.BookTag;
 import lombok.*;
 
 @ToString
@@ -21,7 +22,9 @@ public class BookDto {
     private String description;
     private String pubdate;
 
+    private BookTag bookTag = new BookTag();
+
     public Book toEntity() {
-        return new Book(id, title, image, author, publisher, description, pubdate);
+        return new Book(id, title, image, author, publisher, description, pubdate, bookTag);
     }
 }

--- a/src/main/java/com/core/book/api/book/entity/Book.java
+++ b/src/main/java/com/core/book/api/book/entity/Book.java
@@ -2,10 +2,7 @@ package com.core.book.api.book.entity;
 
 import jakarta.persistence.*;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @AllArgsConstructor
@@ -16,18 +13,19 @@ public class Book {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long book_id;
+    @Column(name = "book_id")
+    private Long id;
 
-    private String title;
-
-    private String book_image;
-
-    private String author;
-
-    private String publisher;
+    private String title; // 책 제목
+    private String book_image; // 책 이미지
+    private String author; // 저자
+    private String publisher; // 출판사
 
     @Column(length = 5000)
-    private String description;
+    private String description; //책 소개
+    private String pubdate; // 출판연도
 
-    private String pubdate;
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "book_tag_id")
+    private BookTag bookTag; //책 태그 - entity
 }

--- a/src/main/java/com/core/book/api/book/entity/BookTag.java
+++ b/src/main/java/com/core/book/api/book/entity/BookTag.java
@@ -1,0 +1,26 @@
+package com.core.book.api.book.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "BOOK_TAG")
+public class BookTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_tag_id")
+    private Long id;
+
+    // 책 top5 태그
+    private String tag1;
+    private String tag2;
+    private String tag3;
+    private String tag4;
+    private String tag5;
+}

--- a/src/main/java/com/core/book/api/book/service/BookService.java
+++ b/src/main/java/com/core/book/api/book/service/BookService.java
@@ -4,6 +4,8 @@ import com.core.book.api.book.dto.BookDto;
 import com.core.book.api.book.dto.ResultDto;
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.book.repository.BookRepository;
+import com.core.book.common.exception.NotFoundException;
+import com.core.book.common.response.ErrorStatus;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -75,6 +77,11 @@ public class BookService {
         List<BookDto> books = Optional.ofNullable(resultDto)
                 .map(ResultDto::getItems)
                 .orElse(Collections.emptyList());
+
+        //예외처리 - 검색한 도서 정보가 없을 경우
+        if (books.isEmpty()) {
+            throw new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage());
+        }
 
         List<Book> book = books.stream()
                 .map(BookDto::toEntity)

--- a/src/main/java/com/core/book/api/book/service/BookService.java
+++ b/src/main/java/com/core/book/api/book/service/BookService.java
@@ -73,21 +73,22 @@ public class BookService {
             log.error("JsonProcessingException occurred while reading value", e);
         }
 
-        //책 정보 데이터 담긴 List 변수 : books
-        List<BookDto> books = Optional.ofNullable(resultDto)
+        //책 정보 데이터 담긴 List 변수 : bookDtos
+        List<BookDto> bookDtos = Optional.ofNullable(resultDto)
                 .map(ResultDto::getItems)
                 .orElse(Collections.emptyList());
 
         //예외처리 - 검색한 도서 정보가 없을 경우
-        if (books.isEmpty()) {
+        if (bookDtos.isEmpty()) {
             throw new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage());
         }
 
-        List<Book> book = books.stream()
+        //Dto 에 담긴 데이터 Entity로 변경 : books
+        List<Book> books = bookDtos.stream()
                 .map(BookDto::toEntity)
                 .collect(Collectors.toList());
 
         //DB 저장
-        return bookRepository.saveAll(book);
+        return bookRepository.saveAll(books);
     }
 }

--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +30,7 @@ public class MemberController {
     @Operation(
             summary = "[임시]")
     @GetMapping("/check")
-    public ApiResponse<Member> getMemberDetails(@AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<ApiResponse<Member>> getMemberDetails(@AuthenticationPrincipal UserDetails userDetails) {
         Member member = memberService.getMemberDetails(userDetails.getUsername());
         return ApiResponse.success(SuccessStatus.SEND_USERDETAIL_SUCCESS, member);
     }
@@ -44,7 +45,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "최소 한개 이상의 USERTAG가 발송되지 않았습니다.")
     })
     @PostMapping("/initial-tags")
-    public ApiResponse<Void> registerInitialTags(@AuthenticationPrincipal UserDetails userDetails, @RequestBody UserTagRequestDTO userTagRequest, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> registerInitialTags(@AuthenticationPrincipal UserDetails userDetails, @RequestBody UserTagRequestDTO userTagRequest, HttpServletResponse response) {
 
         memberService.registerInitialTags(userDetails.getUsername(), userTagRequest, response);
         return ApiResponse.success_only(SuccessStatus.CREATE_USERTAG_SUCCESS);
@@ -59,7 +60,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 마케팅 동의 여부 설정 성공"),
     })
     @GetMapping("/initial-marketing")
-    public ApiResponse<Void> registerInitialMarketing(@AuthenticationPrincipal UserDetails userDetails,
+    public ResponseEntity<ApiResponse<Void>> registerInitialMarketing(@AuthenticationPrincipal UserDetails userDetails,
                                                       @Parameter(
                                                               description = "사용자의 마케팅 동의 여부를 나타내는 파라미터로, 'ok'는 승인, 'no'는 미승인을 의미합니다.",
                                                               example = "ok",

--- a/src/main/java/com/core/book/common/response/ApiResponse.java
+++ b/src/main/java/com/core/book/common/response/ApiResponse.java
@@ -3,6 +3,7 @@ package com.core.book.common.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.ResponseEntity;
 
 @Builder
 @Getter
@@ -14,19 +15,29 @@ public class ApiResponse<T> {
     private final String message;
     private T data;
 
-    public static <T> ApiResponse<T> success(SuccessStatus status, T data) {
-        return ApiResponse.<T>builder()
-                .status(status.getStatusCode())
-                .success(true)
-                .message(status.getMessage())
-                .data(data)
-                .build();
+    public static <T> ResponseEntity<ApiResponse<T>> success(SuccessStatus status, T data) {
+        ApiResponse<T> response = ApiResponse.<T>builder()
+                                .status(status.getStatusCode())
+                                .success(true)
+                                .message(status.getMessage())
+                                .data(data)
+                                .build();
+        return ResponseEntity.status(status.getStatusCode()).body(response);
     }
 
-    public static ApiResponse<Void> success_only(SuccessStatus status) {
+    public static ResponseEntity<ApiResponse<Void>> success_only(SuccessStatus status) {
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                                    .status(status.getStatusCode())
+                                    .success(true)
+                                    .message(status.getMessage())
+                                    .build();
+        return ResponseEntity.status(status.getStatusCode()).body(response);
+    }
+
+    public static ApiResponse<Void> fail_only(ErrorStatus status) {
         return ApiResponse.<Void>builder()
                 .status(status.getStatusCode())
-                .success(true)
+                .success(false)
                 .message(status.getMessage())
                 .build();
     }

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus {
      */
 
     USER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    BOOK_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서를 찾을 수 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus {
 
     USER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     BOOK_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서를 찾을 수 없습니다."),
+    BOOK_NO_MORE_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "더 이상 검색 결과가 없습니다."),
 
     /**
      * 500 SERVER_ERROR


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #41 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 도서 검색 결과 페이징 처리 기능을 구현했습니다.
- 파라미터의 page, size 값으로 페이징 처리를 구현합니다. (page: 페이지 번호, size: 한 번에 표시할 검색 결과 개수)
- 각 파라미터 기본값 => page: 1, size: 10
- 응답 response에 '도서정보/page/size/totalSize(총 검색 결과 개수)' 를 반환합니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/789b9acb-6201-45a3-92ca-2c0569633dbe)
