### PR TITLE
[FIX] 프로필 이미지 확장자 필터링 추가

### DIFF
--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -209,5 +209,32 @@ public class MemberController {
         return ApiResponse.success(SuccessStatus.GET_FOLLOWED_USERS_SUCCESS, followedUsers);
     }
 
+    @Operation(
+            summary = "타인 사용자 정보 조회 API",
+            description = "사용자의 ID를 통해 해당 사용자의 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "타인 사용자 정보 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.")
+    })
+    @GetMapping("/user-info/{id}")
+    public ResponseEntity<ApiResponse<OtherUserInfoResponseDTO>> getOtherUserInfo(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "조회할 사용자의 ID", required = true)
+            @PathVariable Long id) {
+
+        // 상대방 ID 미입력인 경우 예외 처리
+        if (id == null) {
+            throw new BadRequestException(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage());
+        }
+
+        // 조회 사용자 미인증인 경우 예외 처리
+        if (userDetails.getUsername() == null) {
+            throw new BadRequestException(ErrorStatus.USER_UNAUTHORIZED.getMessage());
+        }
+
+        OtherUserInfoResponseDTO userInfo = memberService.getOtherUserInfo(id);
+        return ApiResponse.success(SuccessStatus.GET_USERINFO_SUCCESS, userInfo);
+    }
 
 }

--- a/src/main/java/com/core/book/api/member/dto/OtherUserInfoResponseDTO.java
+++ b/src/main/java/com/core/book/api/member/dto/OtherUserInfoResponseDTO.java
@@ -1,0 +1,20 @@
+package com.core.book.api.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OtherUserInfoResponseDTO {
+    private final Long id;
+    private final String nickname;
+    private final String imageUrl;
+    private final int followedCount;
+
+    public OtherUserInfoResponseDTO(Long id, String nickname, String imageUrl, int followedCount) {
+        this.id = id;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+        this.followedCount = followedCount;
+    }
+}

--- a/src/main/java/com/core/book/api/member/service/MemberService.java
+++ b/src/main/java/com/core/book/api/member/service/MemberService.java
@@ -184,6 +184,11 @@ public class MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
 
+        // 파일 타입 검사 (이미지 파일만 허용)
+        if (!isImageFile(image)) {
+            throw new BadRequestException(ErrorStatus.NOT_ALLOW_IMG_MIME.getMessage());
+        }
+
         // 기존 이미지가 S3에 있는 경우 삭제
         s3Service.deleteFile(member.getImageUrl());
 
@@ -192,6 +197,18 @@ public class MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth
 
         Member updatedMember = member.updateImageUrl(imageUrl);
         memberRepository.save(updatedMember);
+    }
+
+    private boolean isImageFile(MultipartFile file) {
+        // 허용되는 이미지 MIME 타입
+        String contentType = file.getContentType();
+        return contentType != null && (
+                contentType.equals("image/jpeg") ||
+                contentType.equals("image/png") ||
+                contentType.equals("image/jpg") ||
+                contentType.equals("image/bmp") ||
+                contentType.equals("image/webp")
+        );
     }
 
     @Transactional

--- a/src/main/java/com/core/book/api/member/service/MemberService.java
+++ b/src/main/java/com/core/book/api/member/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.core.book.api.member.service;
 
-import com.core.book.api.member.dto.FollowedUserDTO;
-import com.core.book.api.member.dto.InfoOpenRequestDTO;
-import com.core.book.api.member.dto.UserInfoResponseDTO;
-import com.core.book.api.member.dto.UserTagRequestDTO;
+import com.core.book.api.member.dto.*;
 import com.core.book.api.member.entity.Follow;
 import com.core.book.api.member.entity.InfoOpen;
 import com.core.book.api.member.entity.Member;
@@ -328,5 +325,23 @@ public class MemberService implements OAuth2UserService<OAuth2UserRequest, OAuth
                 ))
                 .collect(Collectors.toList());
     }
+
+    @Transactional(readOnly = true)
+    public OtherUserInfoResponseDTO getOtherUserInfo(Long id) {
+        // 조회하려는 타 사용자를 찾습니다.
+        Member targetMember = memberRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 필요한 정보만 DTO로 변환하여 반환
+        int followedCount = targetMember.getFollowing().size();
+
+        return OtherUserInfoResponseDTO.builder()
+                .id(targetMember.getId())
+                .nickname(targetMember.getNickname())
+                .imageUrl(targetMember.getImageUrl())
+                .followedCount(followedCount)
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/core/book/common/exception/UnauthorizedException.java
+++ b/src/main/java/com/core/book/common/exception/UnauthorizedException.java
@@ -1,0 +1,13 @@
+package com.core.book.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BaseException{
+    public UnauthorizedException() {
+        super(HttpStatus.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException(String message) {
+        super(HttpStatus.UNAUTHORIZED, message);
+    }
+}

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus {
     NOT_ALLOW_NICKNAME_FILTER_UNDER_10(HttpStatus.BAD_REQUEST, "닉네임은 10자 이하로 설정해야 합니다."),
     NOT_ALLOW_USERTAG_FILTER_ROLE(HttpStatus.BAD_REQUEST, "닉네임은 영문, 숫자, 한글만 사용할 수 있습니다."),
     NOT_ALLOW_USERTAG_FILTER_LIST(HttpStatus.BAD_REQUEST, "부적절한 닉네임입니다."),
+    NOT_ALLOW_IMG_MIME(HttpStatus.BAD_REQUEST,"이미지 파일(jpg, jpeg, png, bmp, webp) 만 업로드할 수 있습니다."),
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST,"중복된 닉네임입니다."),
     MISSING_INFOOPEN(HttpStatus.BAD_REQUEST,"정보 공개 여부 값이 입력되지 않았습니다."),
 

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -26,6 +26,11 @@ public enum ErrorStatus {
     MISSING_INFOOPEN(HttpStatus.BAD_REQUEST,"정보 공개 여부 값이 입력되지 않았습니다."),
 
     /**
+     * 401 UNAUTHORIZED
+     */
+    USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"인증되지 않은 사용자입니다."),
+
+    /**
      * 404 NOT_FOUND
      */
 

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -43,7 +43,7 @@ public enum ErrorStatus {
      * 500 SERVER_ERROR
      */
 
-    FAIL_UPLOAD_PROFILE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "프로팔 사진이 변경되지 않았습니다."),
+    FAIL_UPLOAD_PROFILE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 사진이 변경되지 않았습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #46

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 프로필 이미지 확장자(jpg, jpeg, png, bmp, webp) 만 올릴 수 있도록 필터링 추가하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/413a66d6-3202-4912-9e1b-9a1335c29964)
