### PR TITLE
[FIX] 닉네임 사용가능 체크 기능 분리

### DIFF
--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -50,7 +50,7 @@ public class MemberController {
 
     @Operation(
             summary = "로그인 API",
-            description = "카카오 엑세스토큰을 통해 사용자의 정보를 등록 및 토큰을 발급합니다."
+            description = "카카오 엑세스토큰을 통해 사용자의 정보를 등록 및 토큰을 발급합니다. (ROLE -> 처음사용자 : GUEST, 일반사용자 : USER, 관리자 : ADMIN)"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
@@ -109,7 +109,7 @@ public class MemberController {
 
     @Operation(
             summary = "처음 사용자용 TAG 등록 API",
-            description = "처음 사용자 추가 정보 등록페이지 에서 TAG를 등록하고 기존사용자로 변경합니다."
+            description = "처음 사용자 추가 정보 등록페이지 에서 TAG를 등록하고 기존사용자로 변경합니다. - 해당 API는 처음사용자 등록할때만 유효합니다, TAG 변경은 다른 API로 수행해야합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "USERTAG 등록 성공"),

--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -204,6 +204,25 @@ public class MemberController {
     }
 
     @Operation(
+            summary = "닉네임 사용 가능 체크 API",
+            description = "변경하려는 닉네임이 사용 가능한지 체크합니다. (닉네임 필터 조건 : 닉네임은 10자 이하로 설정, 닉네임은 영문, 숫자, 한글만 사용가능, 현재 다른 사용자가 사용중인 닉네임은 사용 불가)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 사용 가능"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "닉네임이 입력되지 않았습니다."),
+    })
+    @PostMapping("/check-nickname")
+    public ResponseEntity<ApiResponse<Void>> checkNickname(@RequestParam("nickname") String nickname) {
+        // 닉네임이 입력되지 않았을 경우 예외 처리
+        if (nickname == null || nickname.isEmpty()) {
+            throw new BadRequestException(ErrorStatus.MISSING_NICKNAME.getMessage());
+        }
+
+        memberService.checkNickname(nickname);
+        return ApiResponse.success_only(SuccessStatus.CHECK_NICKNAME_SUCCESS);
+    }
+
+    @Operation(
             summary = "정보 공개 여부 수정 API",
             description = "사용자의 정보 공개 여부를 수정합니다."
     )

--- a/src/main/java/com/core/book/api/member/dto/InfoOpenRequestDTO.java
+++ b/src/main/java/com/core/book/api/member/dto/InfoOpenRequestDTO.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class InfoOpenRequestDTO {
-    private Boolean follow_open;
-    private Boolean content_open;
-    private Boolean comment_open;
-    private Boolean like_open;
+    private Boolean followOpen;
+    private Boolean contentOpen;
+    private Boolean commentOpen;
+    private Boolean likeOpen;
 }

--- a/src/main/java/com/core/book/api/member/dto/UserInfoResponseDTO.java
+++ b/src/main/java/com/core/book/api/member/dto/UserInfoResponseDTO.java
@@ -52,10 +52,10 @@ public class UserInfoResponseDTO {
         private final Boolean likeOpen;
 
         public InfoOpenDTO(InfoOpen infoOpen) {
-            this.followOpen = infoOpen.getFollow_open();
-            this.contentOpen = infoOpen.getContent_open();
-            this.commentOpen = infoOpen.getComment_open();
-            this.likeOpen = infoOpen.getLike_open();
+            this.followOpen = infoOpen.getFollowOpen();
+            this.contentOpen = infoOpen.getContentOpen();
+            this.commentOpen = infoOpen.getCommentOpen();
+            this.likeOpen = infoOpen.getLikeOpen();
         }
     }
 }

--- a/src/main/java/com/core/book/api/member/entity/InfoOpen.java
+++ b/src/main/java/com/core/book/api/member/entity/InfoOpen.java
@@ -17,10 +17,10 @@ public class InfoOpen extends BaseTimeEntity {
     @Column(name = "info_open_id")
     private Long id;
 
-    private Boolean follow_open; // 팔로우 공개 여부
-    private Boolean content_open; // 글 공개 여부
-    private Boolean comment_open; // 댓글 공개 여부
-    private Boolean like_open; // 좋아요 공개 여부
+    private Boolean followOpen; // 팔로우 공개 여부
+    private Boolean contentOpen; // 글 공개 여부
+    private Boolean commentOpen; // 댓글 공개 여부
+    private Boolean likeOpen; // 좋아요 공개 여부
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -28,10 +28,10 @@ public class InfoOpen extends BaseTimeEntity {
 
     public InfoOpen updateInfoOpen(Boolean followOpen, Boolean contentOpen, Boolean commentOpen, Boolean likeOpen) {
         return this.toBuilder()
-                .follow_open(followOpen)
-                .content_open(contentOpen)
-                .comment_open(commentOpen)
-                .like_open(likeOpen)
+                .followOpen(followOpen)
+                .contentOpen(contentOpen)
+                .commentOpen(commentOpen)
+                .likeOpen(likeOpen)
                 .build();
     }
 

--- a/src/main/java/com/core/book/api/member/service/MemberService.java
+++ b/src/main/java/com/core/book/api/member/service/MemberService.java
@@ -213,6 +213,12 @@ public class MemberService {
         memberRepository.save(updatedMember); // Member 객체 반환
     }
 
+    @Transactional
+    public void checkNickname(String nickname) {
+
+        validateNickname(nickname);
+    }
+
     private void validateNickname(String nickname) {
         //10자 이하 인지 체크
         if (nickname.length() > 10) {

--- a/src/main/java/com/core/book/api/member/service/MemberService.java
+++ b/src/main/java/com/core/book/api/member/service/MemberService.java
@@ -83,10 +83,10 @@ public class MemberService {
 
         // 초기 정보 공개 설정
         InfoOpen infoOpen = InfoOpen.builder()
-                .follow_open(true)
-                .content_open(true)
-                .comment_open(true)
-                .like_open(true)
+                .followOpen(true)
+                .contentOpen(true)
+                .commentOpen(true)
+                .likeOpen(true)
                 .member(member)
                 .build();
 
@@ -248,10 +248,10 @@ public class MemberService {
 
         // InfoOpen 정보 업데이트
         infoOpen = infoOpen.updateInfoOpen(
-                infoOpenRequestDTO.getFollow_open(),
-                infoOpenRequestDTO.getContent_open(),
-                infoOpenRequestDTO.getComment_open(),
-                infoOpenRequestDTO.getLike_open()
+                infoOpenRequestDTO.getFollowOpen(),
+                infoOpenRequestDTO.getContentOpen(),
+                infoOpenRequestDTO.getCommentOpen(),
+                infoOpenRequestDTO.getLikeOpen()
         );
 
         infoOpenRepository.save(infoOpen);

--- a/src/main/java/com/core/book/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/core/book/common/config/swagger/SwaggerConfig.java
@@ -44,7 +44,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .info(new Info()
-                        .title("코어 프로젝트 API")
+                        .title("뭉글")
                         .description("독서 커뮤니티 REST API Document - Backend Developer : 태근, 주현")
                         .version("1.0.0"))
                 .components(new Components()

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -23,6 +23,7 @@ public enum SuccessStatus {
 
     UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 사진 변경 성공"),
     UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경 성공"),
+    CHECK_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 사용 가능"),
     UPDATE_INFO_OPEN_SUCCESS(HttpStatus.OK,"정보 공개 수정 성공"),
     DELETE_MEMBER_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공"),
     GET_USERINFO_SUCCESS(HttpStatus.OK,"사용자 정보 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #70

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 기존 닉네임 변경 API에서 닉네임 사용 가능 체크 기능을 분리하여 하나의 API로 따로 구현였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/0d97c4ad-afd2-44d5-89c1-6ec15649ebcf)
