### PR TITLE
[FIX] 책장 전체 조회 API 누락 데이터 및 응답 데이터 구성 수정

### DIFF
--- a/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
+++ b/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
@@ -15,9 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Map;
-
 @Slf4j
 @RequiredArgsConstructor
 @Tag(name = "Bookshelf", description = "Bookshelf 관련 API 입니다.")
@@ -41,12 +38,12 @@ public class BookshelfController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 입력되지 않았습니다.")
     })
     @GetMapping("/api/v1/bookshelf/read")
-    public ResponseEntity<ApiResponse<List<ReadBookshelfResponseDTO>>> showReadBookshelf(@RequestParam("member-id") Long memberId){
+    public ResponseEntity<ApiResponse<ReadBookshelfResponseDTO>> showReadBookshelf(@RequestParam("member-id") Long memberId){
 
-        List<ReadBookshelfResponseDTO> readBookshelfResponseList = bookShelfService.showReadBooks(memberId);
-        log.info("readBookshelfResponseList: {}", readBookshelfResponseList.toString());
+        ReadBookshelfResponseDTO readBookshelfData = bookShelfService.showReadBooks(memberId);
+        log.info("readBookshelfData: {}", readBookshelfData.toString());
 
-        return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, readBookshelfResponseList);
+        return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, readBookshelfData);
     }
 
     @Operation(
@@ -58,12 +55,12 @@ public class BookshelfController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 입력되지 않았습니다.")
     })
     @GetMapping("/api/v1/bookshelf/wish")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> showWishBookshelf(@RequestParam("member-id") Long memberId){
+    public ResponseEntity<ApiResponse<WishBookshelfResponseDTO>> showWishBookshelf(@RequestParam("member-id") Long memberId){
 
-        Map<String, Object> wishBookshelfList = bookShelfService.showWishBooks(memberId);
-        log.info(wishBookshelfList.toString());
+        WishBookshelfResponseDTO wishBookshelfData = bookShelfService.showWishBooks(memberId);
+        log.info(wishBookshelfData.toString());
 
-        return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, wishBookshelfList);
+        return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, wishBookshelfData);
     }
 
     /*
@@ -99,9 +96,9 @@ public class BookshelfController {
     @GetMapping("/api/v1/bookshelf/wish/{id}")
     public ResponseEntity<ApiResponse<WishBooksDTO>> showWishBookshelfDetails(@PathVariable Long id){
 
-            WishBooksDTO showed = bookShelfService.showWishBooksDetails(id);
-            log.info(showed.toString());
-            return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_INFO_SUCCESS, showed);
+        WishBooksDTO showed = bookShelfService.showWishBooksDetails(id);
+        log.info(showed.toString());
+        return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_INFO_SUCCESS, showed);
     }
 
     /*

--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
@@ -10,19 +10,26 @@ import java.util.List;
 @Getter
 public class ReadBookshelfResponseDTO {
 
-    private String date; // 읽은 날짜(월별) (YYYY-M)
-    private int monthlyBookCnt; // 월별 읽은 책 개수
-    private List<MonthlyReadBooksDTO> monthlyReadBooks; // 월별 읽은 책 정보 리스트
-
+    private int totalBookCnt; // 전체 책 개수
+    private List<MonthlyInfoDTO> monthlyInfoList; // 책장 내 월 별로 요구되는 데이터들의 리스트
 
     @Builder
     @Getter
-    public static class MonthlyReadBooksDTO{
+    public static class MonthlyInfoDTO{
+        private String date; // 읽은 날짜(월별) (YYYY-M)
+        private int monthlyBookCnt; // 월별 읽은 책 개수
+        private List<MonthlyReadBookDTO> monthlyReadBookList; // 월별 읽은 책 정보 리스트
 
-        private String isbn; //isbn
-        private String bookImage; // 책 이미지
-        private double starRating; // 평점
-        private String title; // 책 제목
-        private LocalDate readDate; // 읽은 날짜
+        @Builder
+        @Getter
+        public static class MonthlyReadBookDTO {
+
+            private String isbn; //isbn
+            private String bookImage; // 책 이미지
+            private double starRating; // 평점
+            private String title; // 책 제목
+            private LocalDate readDate; // 읽은 날짜
+        }
     }
+
 }

--- a/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfResponseDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfResponseDTO.java
@@ -3,13 +3,23 @@ package com.core.book.api.bookshelf.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Builder
 @Getter
 public class WishBookshelfResponseDTO {
 
-    private String isbn; //isbn
-    private String bookImage; // 책 이미지
-    private String bookTitle; //책 제목
-    private String author; // 저자
-    private String reason; // 읽고 싶은 이유
+    private int totalBookCnt; // 전체 책 개수
+    private List<wishBookDTO> wishBookList; // 읽고 싶은 책 리스트
+
+    @Builder
+    @Getter
+    public static class wishBookDTO {
+        
+        private String isbn; //isbn
+        private String bookImage; // 책 이미지
+        private String bookTitle; //책 제목
+        private String author; // 저자
+        private String reason; // 읽고 싶은 이유
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #88 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- read 책장의 전체 책 개수 데이터를 추가하였습니다.
- wish 책장 전체 조회 API 반환 데이터를 Map 에서 DTO 로 변경하였습니다.
  - return type이 Map 으로 정의될 경우 Swagger 에 표시되는 Response 정보가 정상적으로 구성되지 않고, "additionalProp1": "string" 형식으로 구성되는 이슈를 해결하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
read 책장 전체 조회 API Response 정보 ->
![image](https://github.com/user-attachments/assets/793e7b74-14e9-45b6-a0e1-940ee3844d73)

수정 전 wish 책장 전체 조회 API Swagger Response 정보 ->
![image](https://github.com/user-attachments/assets/2c5ef625-620d-4348-8ee4-e43c745e082e)

수정 후 ->
![image](https://github.com/user-attachments/assets/21182dfb-d86a-40ec-9bb8-304c36ea3168)