### PR TITLE
[FEAT] 책장 전체 조회 페이징 처리 기능 구현

### DIFF
--- a/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
+++ b/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
@@ -38,9 +38,11 @@ public class BookshelfController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 입력되지 않았습니다.")
     })
     @GetMapping("/api/v1/bookshelf/read")
-    public ResponseEntity<ApiResponse<ReadBookshelfResponseDTO>> showReadBookshelf(@RequestParam("member-id") Long memberId){
+    public ResponseEntity<ApiResponse<ReadBookshelfResponseDTO>> showReadBookshelf(
+            @RequestParam("member-id") Long memberId,
+            @RequestParam(value = "page", defaultValue = "1") int page){
 
-        ReadBookshelfResponseDTO readBookshelfData = bookShelfService.showReadBooks(memberId);
+        ReadBookshelfResponseDTO readBookshelfData = bookShelfService.showReadBooks(memberId, page);
         log.info("readBookshelfData: {}", readBookshelfData.toString());
 
         return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, readBookshelfData);
@@ -55,9 +57,11 @@ public class BookshelfController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 입력되지 않았습니다.")
     })
     @GetMapping("/api/v1/bookshelf/wish")
-    public ResponseEntity<ApiResponse<WishBookshelfResponseDTO>> showWishBookshelf(@RequestParam("member-id") Long memberId){
+    public ResponseEntity<ApiResponse<WishBookshelfResponseDTO>> showWishBookshelf(
+            @RequestParam("member-id") Long memberId,
+            @RequestParam(value = "page", defaultValue = "1") int page){
 
-        WishBookshelfResponseDTO wishBookshelfData = bookShelfService.showWishBooks(memberId);
+        WishBookshelfResponseDTO wishBookshelfData = bookShelfService.showWishBooks(memberId, page);
         log.info(wishBookshelfData.toString());
 
         return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, wishBookshelfData);

--- a/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
+++ b/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
@@ -40,9 +40,10 @@ public class BookshelfController {
     @GetMapping("/api/v1/bookshelf/read")
     public ResponseEntity<ApiResponse<ReadBookshelfResponseDTO>> showReadBookshelf(
             @RequestParam("member-id") Long memberId,
-            @RequestParam(value = "page", defaultValue = "1") int page){
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size){
 
-        ReadBookshelfResponseDTO readBookshelfData = bookShelfService.showReadBooks(memberId, page);
+        ReadBookshelfResponseDTO readBookshelfData = bookShelfService.showReadBooks(memberId, page, size);
         log.info("readBookshelfData: {}", readBookshelfData.toString());
 
         return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, readBookshelfData);
@@ -59,9 +60,10 @@ public class BookshelfController {
     @GetMapping("/api/v1/bookshelf/wish")
     public ResponseEntity<ApiResponse<WishBookshelfResponseDTO>> showWishBookshelf(
             @RequestParam("member-id") Long memberId,
-            @RequestParam(value = "page", defaultValue = "1") int page){
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size){
 
-        WishBookshelfResponseDTO wishBookshelfData = bookShelfService.showWishBooks(memberId, page);
+        WishBookshelfResponseDTO wishBookshelfData = bookShelfService.showWishBooks(memberId, page, size);
         log.info(wishBookshelfData.toString());
 
         return ApiResponse.success(SuccessStatus.GET_BOOKSHELF_SUCCESS, wishBookshelfData);

--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
@@ -10,8 +10,9 @@ import java.util.List;
 @Getter
 public class ReadBookshelfResponseDTO {
 
-    private int totalBookCnt; // 전체 책 개수
+    private long totalBookCnt; // 전체 책 개수
     private List<MonthlyInfoDTO> monthlyInfoList; // 책장 내 월 별로 요구되는 데이터들의 리스트
+    private boolean isLast; // 마지막 페이지 여부 (true: 마지막 페이지가 맞음 / false : 마지막 페이지가 아님)
 
     @Builder
     @Getter

--- a/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfResponseDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfResponseDTO.java
@@ -9,8 +9,9 @@ import java.util.List;
 @Getter
 public class WishBookshelfResponseDTO {
 
-    private int totalBookCnt; // 전체 책 개수
+    private long totalBookCnt; // 전체 책 개수
     private List<wishBookDTO> wishBookList; // 읽고 싶은 책 리스트
+    private boolean isLast; // 마지막 페이지 여부 (true: 마지막 페이지가 맞음 / false : 마지막 페이지가 아님)
 
     @Builder
     @Getter

--- a/src/main/java/com/core/book/api/bookshelf/repository/ReadBooksRepository.java
+++ b/src/main/java/com/core/book/api/bookshelf/repository/ReadBooksRepository.java
@@ -2,13 +2,24 @@ package com.core.book.api.bookshelf.repository;
 
 import com.core.book.api.bookshelf.entity.ReadBooks;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ReadBooksRepository extends JpaRepository<ReadBooks, Long> {
 
     // findByMemberIdOrderByReadDateDesc : memberId로 조회하면서 readDate를 기준으로 내림차순 정렬
-    List<ReadBooks> findByMemberIdOrderByReadDateDesc(Long memberId);
+    @Query(value =
+            "SELECT * " +
+            "FROM ReadBooks " +
+            "WHERE user_id = :memberId " +
+            "ORDER BY read_date DESC, readbooks_id DESC " +   // read_date로 우선 정렬, 그다음 id로 정렬
+            "LIMIT :listLimit OFFSET :startPage",
+            nativeQuery = true)
+    List<ReadBooks> findByMemberIdOrderByReadDateDesc(@Param("memberId") Long memberId,
+                                                      @Param("startPage") int startPage,
+                                                      @Param("listLimit") int listLimit);
 
     boolean existsByBookIsbnAndMemberId(String bookIsbn, Long memberId);
 

--- a/src/main/java/com/core/book/api/bookshelf/repository/ReadBooksRepository.java
+++ b/src/main/java/com/core/book/api/bookshelf/repository/ReadBooksRepository.java
@@ -1,25 +1,13 @@
 package com.core.book.api.bookshelf.repository;
 
 import com.core.book.api.bookshelf.entity.ReadBooks;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface ReadBooksRepository extends JpaRepository<ReadBooks, Long> {
 
-    // findByMemberIdOrderByReadDateDesc : memberId로 조회하면서 readDate를 기준으로 내림차순 정렬
-    @Query(value =
-            "SELECT * " +
-            "FROM ReadBooks " +
-            "WHERE user_id = :memberId " +
-            "ORDER BY read_date DESC, readbooks_id DESC " +   // read_date로 우선 정렬, 그다음 id로 정렬
-            "LIMIT :size OFFSET :startPage", // 페이징 처리
-            nativeQuery = true)
-    List<ReadBooks> findByMemberIdOrderByReadDateDesc(@Param("memberId") Long memberId,
-                                                      @Param("startPage") int startPage,
-                                                      @Param("size") int size);
+    Page<ReadBooks> findByMemberIdOrderByReadDateDesc(Long memberId, Pageable pageable);
 
     boolean existsByBookIsbnAndMemberId(String bookIsbn, Long memberId);
 

--- a/src/main/java/com/core/book/api/bookshelf/repository/ReadBooksRepository.java
+++ b/src/main/java/com/core/book/api/bookshelf/repository/ReadBooksRepository.java
@@ -15,11 +15,11 @@ public interface ReadBooksRepository extends JpaRepository<ReadBooks, Long> {
             "FROM ReadBooks " +
             "WHERE user_id = :memberId " +
             "ORDER BY read_date DESC, readbooks_id DESC " +   // read_date로 우선 정렬, 그다음 id로 정렬
-            "LIMIT :listLimit OFFSET :startPage",
+            "LIMIT :size OFFSET :startPage", // 페이징 처리
             nativeQuery = true)
     List<ReadBooks> findByMemberIdOrderByReadDateDesc(@Param("memberId") Long memberId,
                                                       @Param("startPage") int startPage,
-                                                      @Param("listLimit") int listLimit);
+                                                      @Param("size") int size);
 
     boolean existsByBookIsbnAndMemberId(String bookIsbn, Long memberId);
 

--- a/src/main/java/com/core/book/api/bookshelf/repository/WishBooksRepository.java
+++ b/src/main/java/com/core/book/api/bookshelf/repository/WishBooksRepository.java
@@ -2,11 +2,23 @@ package com.core.book.api.bookshelf.repository;
 
 import com.core.book.api.bookshelf.entity.WishBooks;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface WishBooksRepository extends JpaRepository<WishBooks, Long> {
-    List<WishBooks> findByMemberId(Long memberId);
+
+    @Query(value =
+            "SELECT * " +
+            "FROM WishBooks " +
+            "WHERE user_id = :memberId " +
+            "ORDER BY wishbooks_id DESC " +   // read_date로 우선 정렬, 그다음 id로 정렬
+            "LIMIT :listLimit OFFSET :startPage",
+            nativeQuery = true)
+    List<WishBooks> findByMemberId(@Param("memberId") Long memberId,
+                                   @Param("startPage") int startPage,
+                                   @Param("listLimit") int listLimit);
 
     boolean existsByBookIsbnAndMemberId(String bookIsbn, Long memberId);
 }

--- a/src/main/java/com/core/book/api/bookshelf/repository/WishBooksRepository.java
+++ b/src/main/java/com/core/book/api/bookshelf/repository/WishBooksRepository.java
@@ -13,12 +13,12 @@ public interface WishBooksRepository extends JpaRepository<WishBooks, Long> {
             "SELECT * " +
             "FROM WishBooks " +
             "WHERE user_id = :memberId " +
-            "ORDER BY wishbooks_id DESC " +   // read_date로 우선 정렬, 그다음 id로 정렬
-            "LIMIT :listLimit OFFSET :startPage",
+            "ORDER BY wishbooks_id DESC " +
+            "LIMIT :size OFFSET :startPage", // 페이징 처리
             nativeQuery = true)
     List<WishBooks> findByMemberId(@Param("memberId") Long memberId,
                                    @Param("startPage") int startPage,
-                                   @Param("listLimit") int listLimit);
+                                   @Param("size") int size);
 
     boolean existsByBookIsbnAndMemberId(String bookIsbn, Long memberId);
 }

--- a/src/main/java/com/core/book/api/bookshelf/repository/WishBooksRepository.java
+++ b/src/main/java/com/core/book/api/bookshelf/repository/WishBooksRepository.java
@@ -1,24 +1,13 @@
 package com.core.book.api.bookshelf.repository;
 
 import com.core.book.api.bookshelf.entity.WishBooks;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface WishBooksRepository extends JpaRepository<WishBooks, Long> {
 
-    @Query(value =
-            "SELECT * " +
-            "FROM WishBooks " +
-            "WHERE user_id = :memberId " +
-            "ORDER BY wishbooks_id DESC " +
-            "LIMIT :size OFFSET :startPage", // 페이징 처리
-            nativeQuery = true)
-    List<WishBooks> findByMemberId(@Param("memberId") Long memberId,
-                                   @Param("startPage") int startPage,
-                                   @Param("size") int size);
+    Page<WishBooks> findByMemberId(Long memberId, Pageable pageable);
 
     boolean existsByBookIsbnAndMemberId(String bookIsbn, Long memberId);
 }

--- a/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
+++ b/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
@@ -18,6 +18,10 @@ import com.core.book.common.response.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -46,11 +50,14 @@ public class BookShelfService {
     */
     public ReadBookshelfResponseDTO showReadBooks(Long memberId, int page, int size) {
 
-        // 페이징 처리를 위한 변수
-        int startPage = (page - 1) * size; // 조회를 시작할 게시물의 번호 (번호는 0부터 시작)
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "readDate", "id"));
+
+        // 페이징된 결과물 반환
+        Page<ReadBooks> readBookPage = readBooksRepository.findByMemberIdOrderByReadDateDesc(memberId, pageable);
 
         // 책장 주인(회원)이 가진 책장 리스트 반환
-        List<ReadBooks> readBookList = readBooksRepository.findByMemberIdOrderByReadDateDesc(memberId, startPage, size);
+        List<ReadBooks> readBookList = readBookPage.getContent();
 
         // 읽은 책 책장 응답 body 구성을 위한 DTO 리스트들 (초기화)
         List<ReadBookshelfResponseDTO.MonthlyInfoDTO> monthlyInfoDTOList = new ArrayList<>();
@@ -107,8 +114,9 @@ public class BookShelfService {
         }
 
         return ReadBookshelfResponseDTO.builder()
-                .totalBookCnt(readBookList.size())
+                .totalBookCnt(readBookPage.getTotalElements())
                 .monthlyInfoList(monthlyInfoDTOList)
+                .isLast(readBookPage.isLast())
                 .build();
     }
 
@@ -143,11 +151,14 @@ public class BookShelfService {
     */
     public WishBookshelfResponseDTO showWishBooks(Long memberId, int page, int size){
 
-        // 페이징 처리를 위한 변수
-        int startPage = (page - 1) * size; // 조회를 시작할 게시물의 번호 (번호는 0부터 시작)
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
 
-        // 책장 주인(회원)이 가진 '읽고 싶은 책' 책장 리스트 반환
-        List<WishBooks> wishBookList = wishBooksRepository.findByMemberId(memberId, startPage, size);
+        // 페이징된 결과물 반환
+        Page<WishBooks> wishBookPage = wishBooksRepository.findByMemberId(memberId, pageable);
+
+        // 책장 주인(회원)이 가진 책장 리스트 반환
+        List<WishBooks> wishBookList = wishBookPage.getContent();
 
         // wishBookList 의 각 요소를 WishBookshelfResponseDTO.wishBookDTO 로 변환
         List<WishBookshelfResponseDTO.wishBookDTO> wishBookDTOList = wishBookList.stream()
@@ -156,8 +167,9 @@ public class BookShelfService {
 
         // 읽고 싶은 책 전체 데이터를 담는 WishBookshelfResponseDTO 생성 후 반환
         return WishBookshelfResponseDTO.builder()
-                .totalBookCnt(wishBookList.size())
+                .totalBookCnt(wishBookPage.getTotalElements())
                 .wishBookList(wishBookDTOList)
+                .isLast(wishBookPage.isLast())
                 .build();
     }
 

--- a/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
+++ b/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
@@ -44,14 +44,13 @@ public class BookShelfService {
     /*
         '읽은 책' 전체 책장 조회(list)
     */
-    public ReadBookshelfResponseDTO showReadBooks(Long memberId, int page) {
+    public ReadBookshelfResponseDTO showReadBooks(Long memberId, int page, int size) {
 
         // 페이징 처리를 위한 변수
-        int listLimit = 10; // 한 페이지에 표시될 컨텐츠의 개수
-        int startPage = (page - 1) * listLimit; // 조회를 시작할 게시물의 번호
+        int startPage = (page - 1) * size; // 조회를 시작할 게시물의 번호 (번호는 0부터 시작)
 
         // 책장 주인(회원)이 가진 책장 리스트 반환
-        List<ReadBooks> readBookList = readBooksRepository.findByMemberIdOrderByReadDateDesc(memberId, startPage, listLimit);
+        List<ReadBooks> readBookList = readBooksRepository.findByMemberIdOrderByReadDateDesc(memberId, startPage, size);
 
         // 읽은 책 책장 응답 body 구성을 위한 DTO 리스트들 (초기화)
         List<ReadBookshelfResponseDTO.MonthlyInfoDTO> monthlyInfoDTOList = new ArrayList<>();
@@ -142,14 +141,13 @@ public class BookShelfService {
     /*
         '읽고 싶은 책' 전체 책장 조회(list)
     */
-    public WishBookshelfResponseDTO showWishBooks(Long memberId, int page){
+    public WishBookshelfResponseDTO showWishBooks(Long memberId, int page, int size){
 
         // 페이징 처리를 위한 변수
-        int listLimit = 10; // 한 페이지에 표시될 컨텐츠의 개수
-        int startPage = (page - 1) * listLimit; // 조회를 시작할 게시물의 번호
+        int startPage = (page - 1) * size; // 조회를 시작할 게시물의 번호 (번호는 0부터 시작)
 
         // 책장 주인(회원)이 가진 '읽고 싶은 책' 책장 리스트 반환
-        List<WishBooks> wishBookList = wishBooksRepository.findByMemberId(memberId, startPage, listLimit);
+        List<WishBooks> wishBookList = wishBooksRepository.findByMemberId(memberId, startPage, size);
 
         // wishBookList 의 각 요소를 WishBookshelfResponseDTO.wishBookDTO 로 변환
         List<WishBookshelfResponseDTO.wishBookDTO> wishBookDTOList = wishBookList.stream()

--- a/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
+++ b/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
@@ -44,10 +44,14 @@ public class BookShelfService {
     /*
         '읽은 책' 전체 책장 조회(list)
     */
-    public ReadBookshelfResponseDTO showReadBooks(Long memberId) {
+    public ReadBookshelfResponseDTO showReadBooks(Long memberId, int page) {
+
+        // 페이징 처리를 위한 변수
+        int listLimit = 10; // 한 페이지에 표시될 컨텐츠의 개수
+        int startPage = (page - 1) * listLimit; // 조회를 시작할 게시물의 번호
 
         // 책장 주인(회원)이 가진 책장 리스트 반환
-        List<ReadBooks> readBookList = readBooksRepository.findByMemberIdOrderByReadDateDesc(memberId);
+        List<ReadBooks> readBookList = readBooksRepository.findByMemberIdOrderByReadDateDesc(memberId, startPage, listLimit);
 
         // 읽은 책 책장 응답 body 구성을 위한 DTO 리스트들 (초기화)
         List<ReadBookshelfResponseDTO.MonthlyInfoDTO> monthlyInfoDTOList = new ArrayList<>();
@@ -138,10 +142,14 @@ public class BookShelfService {
     /*
         '읽고 싶은 책' 전체 책장 조회(list)
     */
-    public WishBookshelfResponseDTO showWishBooks(Long memberId){
+    public WishBookshelfResponseDTO showWishBooks(Long memberId, int page){
+
+        // 페이징 처리를 위한 변수
+        int listLimit = 10; // 한 페이지에 표시될 컨텐츠의 개수
+        int startPage = (page - 1) * listLimit; // 조회를 시작할 게시물의 번호
 
         // 책장 주인(회원)이 가진 '읽고 싶은 책' 책장 리스트 반환
-        List<WishBooks> wishBookList = wishBooksRepository.findByMemberId(memberId);
+        List<WishBooks> wishBookList = wishBooksRepository.findByMemberId(memberId, startPage, listLimit);
 
         // wishBookList 의 각 요소를 WishBookshelfResponseDTO.wishBookDTO 로 변환
         List<WishBookshelfResponseDTO.wishBookDTO> wishBookDTOList = wishBookList.stream()


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #91 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- read/wish 책장 전체 조회 시 페이징 처리 기능을 구현하였습니다. (page 기본 값: 1, size 기본 값: 10)
- url 예시 : /api/v1/bookshelf/wish?member-id=1&page=1&size=10
- url 예시 : /api/v1/bookshelf/wish?member-id=1&page=1&size=10
- read 책장 전체 조회 Response Body 구성: 전체 정보 > 월별 정보 > 해당 월에 포함된 책 정보
&ensp;- 전체 정보 = 전체 책 개수 / 마지막 페이지 여부
&ensp;- 월별 정보 = 읽은 날짜(월별)(YYYY-M) / 월별 읽은 책 개수
&ensp;- 해당 월에 포함된 책 정보 = isbn / 책 이미지 / 평점 / 책 제목 / 읽은 날짜
 
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
read 책장 전체 조회(1) =>
![image](https://github.com/user-attachments/assets/7c99b38f-191f-44c9-8949-3d703d9869c4)

read 책장 전체 조회(2) =>
![image](https://github.com/user-attachments/assets/bf30344b-056a-4a66-8bb9-a64ce285805b)

wish 책장 전체 조회 =>
![image](https://github.com/user-attachments/assets/d5afb470-d4fc-4723-9cac-45144e2550b1)
