### PR TITLE
[FIX] 책장 전체 조회 API 응답에 page 데이터 추가

### DIFF
--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
@@ -12,6 +12,7 @@ public class ReadBookshelfResponseDTO {
 
     private long totalBookCnt; // 전체 책 개수
     private List<MonthlyInfoDTO> monthlyInfoList; // 책장 내 월 별로 요구되는 데이터들의 리스트
+    private int page; // 현재 페이지 번호
     private boolean isLast; // 마지막 페이지 여부 (true: 마지막 페이지가 맞음 / false : 마지막 페이지가 아님)
 
     @Builder

--- a/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfResponseDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfResponseDTO.java
@@ -11,6 +11,7 @@ public class WishBookshelfResponseDTO {
 
     private long totalBookCnt; // 전체 책 개수
     private List<wishBookDTO> wishBookList; // 읽고 싶은 책 리스트
+    private int page; // 현재 페이지 번호
     private boolean isLast; // 마지막 페이지 여부 (true: 마지막 페이지가 맞음 / false : 마지막 페이지가 아님)
 
     @Builder

--- a/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
+++ b/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
@@ -132,6 +132,7 @@ public class BookShelfService {
         return ReadBookshelfResponseDTO.builder()
                 .totalBookCnt(readBookPage.getTotalElements())
                 .monthlyInfoList(monthlyInfoDTOList)
+                .page(page)
                 .isLast(readBookPage.isLast())
                 .build();
     }
@@ -185,6 +186,7 @@ public class BookShelfService {
         return WishBookshelfResponseDTO.builder()
                 .totalBookCnt(wishBookPage.getTotalElements())
                 .wishBookList(wishBookDTOList)
+                .page(page)
                 .isLast(wishBookPage.isLast())
                 .build();
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #106 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 책장 전체 조회 API 응답에 페이징 처리를 위한 page(현재 페이지 번호) 데이터를 추가하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/5ff43adc-5ae3-4cd1-ab6f-309645d3705b)
