### PR TITLE
[FIX] 기존 BookDTO 사용 코드 BookInfoDTO로 변경

### DIFF
--- a/src/main/java/com/core/book/api/book/controller/BookController.java
+++ b/src/main/java/com/core/book/api/book/controller/BookController.java
@@ -1,8 +1,10 @@
 package com.core.book.api.book.controller;
 
+import com.core.book.api.book.dto.BookInfoDTO;
 import com.core.book.api.book.dto.BookResponseDTO;
 import com.core.book.api.book.service.BookService;
 import com.core.book.common.exception.BadRequestException;
+import com.core.book.common.exception.NotFoundException;
 import com.core.book.common.response.ApiResponse;
 import com.core.book.common.response.ErrorStatus;
 import com.core.book.common.response.SuccessStatus;
@@ -26,7 +28,7 @@ public class BookController {
     private final BookService bookService;
 
     @Operation(
-            summary = "도서 데이터 요청 API",
+            summary = "책 검색 API",
             description = "외부 API에 도서 데이터를 요청해 가져옵니다."
     )
     @ApiResponses({
@@ -46,8 +48,29 @@ public class BookController {
             throw new BadRequestException(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage());
         }
 
-        BookResponseDTO bookResponseDTO = bookService.book(text, page, size);
+        BookResponseDTO bookList = bookService.bookSearch(text, page, size);
 
-        return ApiResponse.success(SuccessStatus.BOOK_SEARCH_SUCCESS, bookResponseDTO);
+        return ApiResponse.success(SuccessStatus.BOOK_SEARCH_SUCCESS, bookList);
+    }
+
+    @Operation(
+            summary = "책 정보 자세히보기 API",
+            description = "책 정보 자세히보기 페이지에 표시되는 데이터를 반환합니다. (데이터: 책 정보, 전체 평점, 전체 태그(Best 5), 리뷰 목록)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "책 결과 반환 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "해당 도서의 검색 결과가 없습니다.")
+    })
+    @GetMapping("/api/v1/book/info")
+    public ResponseEntity<ApiResponse<BookInfoDTO>> bookInfo(
+            @RequestParam("isbn") String isbn){
+
+        BookInfoDTO bookInfo = bookService.bookInfo(isbn);
+
+        if(bookInfo == null){
+            throw new NotFoundException(ErrorStatus.BOOK_SEARCH_NOTFOUND_EXCEPTION.getMessage());
+        }
+
+        return ApiResponse.success(SuccessStatus.BOOK_SEARCH_SUCCESS, bookInfo);
     }
 }

--- a/src/main/java/com/core/book/api/book/controller/BookController.java
+++ b/src/main/java/com/core/book/api/book/controller/BookController.java
@@ -29,7 +29,7 @@ public class BookController {
 
     @Operation(
             summary = "책 검색 API",
-            description = "외부 API에 도서 데이터를 요청해 가져옵니다."
+            description = "외부 API에 도서 데이터를 요청해 가져옵니다. 반환 값 중 description(책 소개)은 검색 페이지에서 사용되지 않는 데이터 입니다. 다만 타 API에 책 데이터를 넘겨주는 경우에는 같이 사용됩니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "책 결과 반환 성공"),

--- a/src/main/java/com/core/book/api/book/dto/BookDTO.java
+++ b/src/main/java/com/core/book/api/book/dto/BookDTO.java
@@ -1,7 +1,5 @@
 package com.core.book.api.book.dto;
 
-import com.core.book.api.book.entity.Book;
-import com.core.book.api.book.entity.BookTag;
 import lombok.*;
 
 @ToString
@@ -20,11 +18,4 @@ public class BookDTO {
     private String publisher;
     private String description;
     private String pubdate;
-
-    @Builder.Default
-    private BookTag bookTag = new BookTag();
-
-    public Book toEntity() {
-        return new Book(isbn, title, image, author, publisher, description, pubdate, bookTag);
-    }
 }

--- a/src/main/java/com/core/book/api/book/dto/BookInfoDTO.java
+++ b/src/main/java/com/core/book/api/book/dto/BookInfoDTO.java
@@ -1,0 +1,17 @@
+package com.core.book.api.book.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class BookInfoDTO {
+
+    private String isbn; // isbn
+    private String image; // 책 이미지
+    private String title; // 책 제목
+    private String author; // 저자
+    private String publisher; // 출판사
+    private String pubdate; // 출판 날짜
+    private String description; // 책 소개
+}

--- a/src/main/java/com/core/book/api/book/dto/BookInfoDTO.java
+++ b/src/main/java/com/core/book/api/book/dto/BookInfoDTO.java
@@ -1,5 +1,7 @@
 package com.core.book.api.book.dto;
 
+import com.core.book.api.book.entity.Book;
+import com.core.book.api.book.entity.BookTag;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,4 +16,20 @@ public class BookInfoDTO {
     private String publisher; // 출판사
     private String pubdate; // 출판 날짜
     private String description; // 책 소개
+
+    public Book toEntity() {
+
+        BookTag bookTag = new BookTag(); // ID는 자동 생성
+
+        return Book.builder()
+                .isbn(isbn)
+                .title(title)
+                .bookImage(image)
+                .author(author)
+                .publisher(publisher)
+                .description(description)
+                .pubdate(pubdate)
+                .bookTag(bookTag)
+                .build();
+    }
 }

--- a/src/main/java/com/core/book/api/book/dto/BookResponseDTO.java
+++ b/src/main/java/com/core/book/api/book/dto/BookResponseDTO.java
@@ -11,18 +11,6 @@ public class BookResponseDTO {
 
     private int totalSize; // 검색된 책 전체 개수
     private int page; // 현재 페이지 번호
-    private List<BookDTO> bookList; // 검색된 책 List
+    private List<BookInfoDTO> bookList; // 검색된 책 List
     private boolean isLast; // 마지막 페이지 여부
-
-    @Builder
-    @Getter
-    public static class BookDTO{
-
-        private String isbn; // isbn
-        private String title; // 책 제목
-        private String image; // 책 이미지
-        private String author; // 저자
-        private String publisher; // 출판사
-        private String pubdate; // 출판 날짜
-    }
 }

--- a/src/main/java/com/core/book/api/book/entity/Book.java
+++ b/src/main/java/com/core/book/api/book/entity/Book.java
@@ -7,6 +7,7 @@ import lombok.*;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @ToString
 @Getter
 public class Book {

--- a/src/main/java/com/core/book/api/book/service/BookService.java
+++ b/src/main/java/com/core/book/api/book/service/BookService.java
@@ -54,16 +54,9 @@ public class BookService {
                 .map(ResultDTO::getItems)
                 .orElse(Collections.emptyList());
 
-        // bookDTOs를 BookResponseDTO.BookDTO로 변환
-        List<BookResponseDTO.BookDTO> responseBookDTOs = bookList.stream()
-                .map(bookDTO -> BookResponseDTO.BookDTO.builder()
-                        .isbn(bookDTO.getIsbn())
-                        .title(bookDTO.getTitle())
-                        .image(bookDTO.getImage())
-                        .author(bookDTO.getAuthor())
-                        .publisher(bookDTO.getPublisher())
-                        .pubdate(bookDTO.getPubdate())
-                        .build())
+        // bookList를 BookInfoDTO로 변환
+        List<BookInfoDTO> BookInfoList = bookList.stream()
+                .map(this::convertToBookInfoDTO)
                 .collect(Collectors.toList());
 
         // 마지막 페이지 여부 검사
@@ -75,7 +68,7 @@ public class BookService {
         return BookResponseDTO.builder()
                 .totalSize(resultDTO.getTotal())
                 .page(page)
-                .bookList(responseBookDTOs)
+                .bookList(BookInfoList)
                 .isLast(isLast)
                 .build();
     }

--- a/src/main/java/com/core/book/api/book/service/BookService.java
+++ b/src/main/java/com/core/book/api/book/service/BookService.java
@@ -1,13 +1,13 @@
 package com.core.book.api.book.service;
 
-import com.core.book.api.book.dto.BookDTO;
-import com.core.book.api.book.dto.BookResponseDTO;
-import com.core.book.api.book.dto.ChannelDTO;
-import com.core.book.api.book.dto.ResultDTO;
+import com.core.book.api.book.dto.*;
+import com.core.book.api.book.entity.Book;
+import com.core.book.api.book.repository.BookRepository;
 import com.core.book.common.exception.NotFoundException;
 import com.core.book.common.response.ErrorStatus;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.RequestEntity;
@@ -23,8 +23,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class BookService {
+
+    private final BookRepository bookRepository;
 
     @Value("${naver-client-id}")
     private String clientId;
@@ -32,22 +35,111 @@ public class BookService {
     @Value("${naver-client-secret}")
     private String clientSecret;
 
-    public BookResponseDTO book(String text, int page, int size){
+    public BookResponseDTO bookSearch(String text, int page, int size){
 
         int start = (page - 1) * size + 1; //검색 시작 위치 변수
         boolean isLast = false; // 마지막 페이지 여부 (true = 마지막 페이지)
 
-        // String apiURL
-        URI uri = UriComponentsBuilder
+        // 외부 도서 API 요청
+        URI uri = uriComponentBuild(text, null, page, size);
+        ResultDTO resultDTO = fetchBookData(uri);
+
+        // 예외 처리 - "더 이상 검색 결과가 없습니다."
+        if(resultDTO.getTotal() != 0 && resultDTO.getTotal() < start){
+            throw new NotFoundException(ErrorStatus.BOOK_NO_MORE_FOUND_EXCEPTION.getMessage());
+        }
+
+        // 책 정보 데이터 담긴 List 변수 : bookList
+        List<BookDTO> bookList = Optional.of(resultDTO)
+                .map(ResultDTO::getItems)
+                .orElse(Collections.emptyList());
+
+        // bookDTOs를 BookResponseDTO.BookDTO로 변환
+        List<BookResponseDTO.BookDTO> responseBookDTOs = bookList.stream()
+                .map(bookDTO -> BookResponseDTO.BookDTO.builder()
+                        .isbn(bookDTO.getIsbn())
+                        .title(bookDTO.getTitle())
+                        .image(bookDTO.getImage())
+                        .author(bookDTO.getAuthor())
+                        .publisher(bookDTO.getPublisher())
+                        .pubdate(bookDTO.getPubdate())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 마지막 페이지 여부 검사
+        if(start + size >= resultDTO.getTotal()){
+            isLast = true;
+        }
+
+        // BookResponseDTO 반환
+        return BookResponseDTO.builder()
+                .totalSize(resultDTO.getTotal())
+                .page(page)
+                .bookList(responseBookDTOs)
+                .isLast(isLast)
+                .build();
+    }
+
+    public BookInfoDTO bookInfo(String isbn){
+
+        BookDTO bookDTO;
+
+        // BOOK DB에서 책 데이터 찾기
+        if(bookRepository.existsByIsbn(isbn)){
+
+            log.info("도서 정보 DB 요청");
+            
+            Book book = bookRepository.findById(isbn)
+                    .orElseThrow(() -> new NotFoundException(ErrorStatus.BOOK_NOTFOUND_EXCEPTION.getMessage()));
+            bookDTO = convertToBookDTO(book);
+
+        }
+        else{ // (DB에 없다면) 외부 도서 API에 데이터 요청
+
+            log.info("도서 정보 외부 API 요청");
+
+            // 외부 도서 API 요청
+            URI uri = uriComponentBuild(null, isbn, 1, 10);
+            ResultDTO resultDTO = fetchBookData(uri);
+
+            // 검색 결과 데이터 변환
+            List<BookDTO> bookList = Optional.of(resultDTO)
+                    .map(ResultDTO::getItems)
+                    .orElse(Collections.emptyList());
+            bookDTO = bookList.isEmpty() ? null : bookList.get(0); // List의 첫 번째 값 가져와 Book entity로 변환
+        }
+
+        if(bookDTO != null){
+            return convertToBookInfoDTO(bookDTO);
+        } else {
+            return null;
+        }
+    }
+
+    // 외부 도서 API 에 요청할 URI 생성
+    private URI uriComponentBuild(String text, String isbn, int page, int size){
+
+        int start = (page - 1) * size + 1; //검색 시작 위치 변수
+        String searchType = "book.xml";
+        if(isbn != null){
+            searchType = "book_adv.xml";
+        }
+
+        return UriComponentsBuilder
                 .fromUriString("https://openapi.naver.com")
-                .path("/v1/search/book.xml")
+                .path("/v1/search/" + searchType)
                 .queryParam("query", text) //검색어
                 .queryParam("display", size) //한 번에 표시할 검색 결과 개수
                 .queryParam("start", start) //검색 시작 위치
                 .queryParam("sort", "sim") //검색 결과 정렬 방법
+                .queryParam("d_isbn", isbn) // 검색할 ISBN
                 .encode()
                 .build()
                 .toUri();
+    }
+
+    // 도서 데이터 요청 & Xml 파싱 후 resultDTO 반환
+    private ResultDTO fetchBookData(URI uri){
 
         // Spring 요청 제공 클래스
         RequestEntity<Void> req = RequestEntity.get(uri)
@@ -76,41 +168,32 @@ public class BookService {
             throw new NotFoundException(ErrorStatus.FAIL_REQUEST_BOOK_INFO.getMessage());
         }
 
-        ResultDTO resultDTO = channelDTO.getChannel();
+        return channelDTO.getChannel();
+    }
 
-        // 예외 처리 - "더 이상 검색 결과가 없습니다."
-        if(resultDTO.getTotal() != 0 && resultDTO.getTotal() < start){
-            throw new NotFoundException(ErrorStatus.BOOK_NO_MORE_FOUND_EXCEPTION.getMessage());
-        }
+    // Book을 BookInfoDTO로 변환
+    private BookDTO convertToBookDTO(Book book){
+        return BookDTO.builder()
+                .isbn(book.getIsbn())
+                .image(book.getBookImage())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .publisher(book.getPublisher())
+                .pubdate(book.getPubdate())
+                .description(book.getDescription())
+                .build();
+    }
 
-        // 책 정보 데이터 담긴 List 변수 : bookDTOS
-        List<BookDTO> bookDTOs = Optional.of(resultDTO)
-                .map(ResultDTO::getItems)
-                .orElse(Collections.emptyList());
-
-        // bookDTOs를 BookResponseDTO.BookDTO로 변환
-        List<BookResponseDTO.BookDTO> responseBookDTOs = bookDTOs.stream()
-                .map(bookDTO -> BookResponseDTO.BookDTO.builder()
-                        .isbn(bookDTO.getIsbn())
-                        .title(bookDTO.getTitle())
-                        .image(bookDTO.getImage())
-                        .author(bookDTO.getAuthor())
-                        .publisher(bookDTO.getPublisher())
-                        .pubdate(bookDTO.getPubdate())
-                        .build())
-                .collect(Collectors.toList());
-
-        // 마지막 페이지 여부 검사
-        if(start + size >= resultDTO.getTotal()){
-            isLast = true;
-        }
-
-        // BookResponseDTO 반환
-        return BookResponseDTO.builder()
-                .totalSize(resultDTO.getTotal())
-                .page(page)
-                .bookList(responseBookDTOs)
-                .isLast(isLast)
+    // BookDTO를 BookInfoDTO로 변환
+    private BookInfoDTO convertToBookInfoDTO(BookDTO bookDTO){
+        return BookInfoDTO.builder()
+                .isbn(bookDTO.getIsbn())
+                .image(bookDTO.getImage())
+                .title(bookDTO.getTitle())
+                .author(bookDTO.getAuthor())
+                .publisher(bookDTO.getPublisher())
+                .pubdate(bookDTO.getPubdate())
+                .description(bookDTO.getDescription())
                 .build();
     }
 }

--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfRequestDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfRequestDTO.java
@@ -1,6 +1,6 @@
 package com.core.book.api.bookshelf.dto;
 
-import com.core.book.api.book.dto.BookDTO;
+import com.core.book.api.book.dto.BookInfoDTO;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,6 +8,6 @@ import lombok.Getter;
 @Getter
 public class ReadBookshelfRequestDTO {
 
-    private BookDTO book;
+    private BookInfoDTO bookInfo;
     private ReadBooksDTO readBooks;
 }

--- a/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfRequestDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/WishBookshelfRequestDTO.java
@@ -1,6 +1,6 @@
 package com.core.book.api.bookshelf.dto;
 
-import com.core.book.api.book.dto.BookDTO;
+import com.core.book.api.book.dto.BookInfoDTO;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,6 +8,6 @@ import lombok.Getter;
 @Getter
 public class WishBookshelfRequestDTO {
 
-    private BookDTO book;
+    private BookInfoDTO bookInfo;
     private WishBooksDTO wishBooks;
 }

--- a/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
+++ b/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
@@ -1,6 +1,6 @@
 package com.core.book.api.bookshelf.service;
 
-import com.core.book.api.book.dto.BookDTO;
+import com.core.book.api.book.dto.BookInfoDTO;
 import com.core.book.api.bookshelf.dto.*;
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.book.repository.BookRepository;
@@ -271,14 +271,14 @@ public class BookShelfService {
     @Transactional
     public void createReadBookshelf(ReadBookshelfRequestDTO readBookshelfDTO){
 
-        String bookIsbn = readBookshelfDTO.getBook().getIsbn();
+        String bookIsbn = readBookshelfDTO.getBookInfo().getIsbn();
         Long memberId = readBookshelfDTO.getReadBooks().getMemberId();
 
         // 예외처리 : 이미 나의 책장에 등록된 책에 대하여 등록 불가
         checkDuplicateBookshelf(bookIsbn, memberId, true);
 
         // 책이 이미 BOOK DB에 존재한다면 -> DB 저장X / 없다면 -> DB 저장O
-        Book book = saveBookIfNotExists(bookIsbn, readBookshelfDTO.getBook());
+        Book book = saveBookIfNotExists(bookIsbn, readBookshelfDTO.getBookInfo());
 
         // 예외처리 : 회원 존재 여부 확인
         Member member = getMemberById(memberId);
@@ -294,14 +294,14 @@ public class BookShelfService {
     @Transactional
     public void createWishBookshelf(WishBookshelfRequestDTO wishBookshelfDTO){
 
-        String bookIsbn = wishBookshelfDTO.getBook().getIsbn();
+        String bookIsbn = wishBookshelfDTO.getBookInfo().getIsbn();
         Long memberId = wishBookshelfDTO.getWishBooks().getMemberId();
 
         // 예외처리 : 이미 나의 책장에 등록된 책에 대하여 등록 불가
         checkDuplicateBookshelf(bookIsbn, memberId, false);
 
         // 책이 이미 BOOK DB에 존재한다면 -> DB 저장X / 없다면 -> DB 저장O
-        Book book = saveBookIfNotExists(bookIsbn, wishBookshelfDTO.getBook());
+        Book book = saveBookIfNotExists(bookIsbn, wishBookshelfDTO.getBookInfo());
 
         // 예외처리 : 회원 존재 여부 확인
         Member member = getMemberById(memberId);
@@ -325,11 +325,11 @@ public class BookShelfService {
     }
 
     // 책 존재 확인 및 저장 메서드
-    private Book saveBookIfNotExists(String bookIsbn, BookDTO bookDTO){
+    private Book saveBookIfNotExists(String bookIsbn, BookInfoDTO bookInfoDTO){
         boolean existsBook = bookRepository.existsByIsbn(bookIsbn);
         if(!existsBook){
             // 책이 DB에 존재하지 않는 경우
-            bookRepository.save(bookDTO.toEntity());
+            bookRepository.save(bookInfoDTO.toEntity());
         }
 
         return bookRepository.findById(bookIsbn)
@@ -457,11 +457,11 @@ public class BookShelfService {
         /* (1) 읽은 책 책장에 등록 */
 
         // 책 정보 가져오기
-        BookDTO bookDTO = convertToBookDTO(wishBooks.getBook());
+        BookInfoDTO bookInfoDTO = convertToBookInfoDTO(wishBooks.getBook());
 
         // ReadBookshelfRequestDTO 만들기
         ReadBookshelfRequestDTO readBookshelfRequestDTO = ReadBookshelfRequestDTO.builder()
-                .book(bookDTO)
+                .bookInfo(bookInfoDTO)
                 .readBooks(readBooksDTO)
                 .build();
 
@@ -473,16 +473,15 @@ public class BookShelfService {
     }
 
     // book을 BookDTO로 변경하는 메서드
-    private BookDTO convertToBookDTO(Book book){
-        return BookDTO.builder()
+    private BookInfoDTO convertToBookInfoDTO(Book book){
+        return BookInfoDTO.builder()
                 .isbn(book.getIsbn())
-                .title(book.getTitle())
                 .image(book.getBookImage())
+                .title(book.getTitle())
                 .author(book.getAuthor())
                 .publisher(book.getPublisher())
-                .description(book.getDescription())
                 .pubdate(book.getPubdate())
-                .bookTag(book.getBookTag())
+                .description(book.getDescription())
                 .build();
     }
 

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -48,6 +48,7 @@ public enum ErrorStatus {
 
     USER_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     BOOK_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서를 찾을 수 없습니다."),
+    BOOK_SEARCH_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서의 검색 결과가 없습니다."),
     BOOK_NO_MORE_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "더 이상 검색 결과가 없습니다."),
     BOOKSHELF_INFO_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 책장에서 선택된 도서를 찾을 수 없습니다."),
     BOOKSHELF_NOTFOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 책장에서 도서를 찾을 수 없습니다."),

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -19,7 +19,6 @@ public enum SuccessStatus {
     SET_USER_MARKETING_SUCCESS(HttpStatus.OK, "유저 마케팅 동의 여부 설정 성공"),
 
     SEND_QUESTION_SUCCESS(HttpStatus.OK, "문제 발송 성공"),
-    BOOK_SEARCH_SUCCESS(HttpStatus.OK, "책 결과 반환 성공"),
 
     UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 사진 변경 성공"),
     UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경 성공"),
@@ -31,6 +30,8 @@ public enum SuccessStatus {
     USER_UNFOLLOW_SUCCESS(HttpStatus.OK,"언팔로우 성공"),
     GET_FOLLOWED_USERS_SUCCESS(HttpStatus.OK,"팔로우 중인 사용자 목록 조회 성공"),
     GET_FOLLOWER_USERS_SUCCESS(HttpStatus.OK, "팔로워 사용자 목록 조회 성공"),
+
+    BOOK_SEARCH_SUCCESS(HttpStatus.OK, "책 결과 반환 성공"),
 
     GET_BOOKSHELF_SUCCESS(HttpStatus.OK,"책장 조회 성공"),
     GET_BOOKSHELF_INFO_SUCCESS(HttpStatus.OK,"책장 상세 정보 조회 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #109 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 BookDTO를 사용하던 코드를 BookInfoDTO를 사용하도록 변경하였습니다.
- 이를 통해 BookDTO의 필요 없는 데이터(link, discount) 및 (책장 등록 API의) RequestBody에서 입력 받지 않아도 될 bookTag 데이터를 삭제하여 클라이언트 단에서 혼동될 요소를 제거합니다.
- 책 검색 API에서 반환되는 bookList 요소 중 'description(책 소개)'은 검색 페이지에서 사용되지 않는 데이터 입니다.
- 다만, 검색 페이지를 통해 책을 등록하는 로직이 수행될 경우 (e.g. 책장 등록 API) bookList의 모든 데이터를 사용합니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
책 검색 API 반환 데이터 ->
![image](https://github.com/user-attachments/assets/31c1339f-69c1-4e99-8b32-501b645a748f)

책 정보 자세히 보기 API 반환 데이터 (현재 개발중, 추가 데이터 있음) ->
![image](https://github.com/user-attachments/assets/64453fce-3be5-4890-a94b-fbe57fe9a40d)

책장 등록 API Request Body (기존에 필요 없던 link, discount, bookTag 데이터 삭제함) ->
![image](https://github.com/user-attachments/assets/4e8a5b9f-0f04-4353-9a13-d8ce7bc2e419)
![image](https://github.com/user-attachments/assets/44bf38e1-90d8-496e-941a-5d91d4ac510f)

