### PR TITLE
[FIX] 게시글 전체보기 API 데이터 불러오기 로직 수정

### DIFF
--- a/src/main/java/com/core/book/api/article/controller/ArticleViewController.java
+++ b/src/main/java/com/core/book/api/article/controller/ArticleViewController.java
@@ -1,7 +1,7 @@
 package com.core.book.api.article.controller;
 
+import com.core.book.api.article.dto.ArticleListResponseDTO;
 import com.core.book.api.article.dto.ReviewArticleDetailDTO;
-import com.core.book.api.article.dto.ReviewArticleListResponseDTO;
 import com.core.book.api.article.service.ArticleViewService;
 import com.core.book.common.response.ApiResponse;
 import com.core.book.common.response.SuccessStatus;
@@ -29,13 +29,13 @@ public class ArticleViewController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "게시글 타입이 존재하지 않습니다."),
     })
     @GetMapping("/{articleType}")
-    public ResponseEntity<ApiResponse<ReviewArticleListResponseDTO>> getAllArticles(
+    public ResponseEntity<ApiResponse<ArticleListResponseDTO>> getAllArticles(
             @PathVariable String articleType,
             @RequestParam int page,
             @RequestParam int size
     ) {
-        ReviewArticleListResponseDTO reviewArticleListResponseDTO = articleViewService.getAllArticles(articleType, page, size);
-        return ApiResponse.success(SuccessStatus.GET_ARTICLE_LIST_SUCCESS, reviewArticleListResponseDTO);
+        ArticleListResponseDTO articleListResponseDTO = articleViewService.getAllArticles(articleType, page, size);
+        return ApiResponse.success(SuccessStatus.GET_ARTICLE_LIST_SUCCESS, articleListResponseDTO);
     }
 
     @Operation(

--- a/src/main/java/com/core/book/api/article/dto/ArticleListDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/ArticleListDTO.java
@@ -1,0 +1,38 @@
+package com.core.book.api.article.dto;
+
+import com.core.book.api.article.entity.ArticleType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ArticleListDTO {
+    private final Long articleId;
+    private final Long memberId;
+    private final String profileImage;
+    private final String nickname;
+    private final String content;
+    private final long likeCnt;    // 공통 필드
+    private final long commentCnt; // 공통 필드
+    private final long quoCnt;
+    private final String bookImage;
+    private final String title;
+    private final String author;
+    private final ArticleType articleType; // 게시글 타입 구분을 위한 필드
+
+    @Builder
+    public ArticleListDTO(Long articleId, Long memberId, String profileImage, String nickname, String content,
+                          long likeCnt, long commentCnt, long quoCnt, String bookImage, String title, String author, ArticleType articleType) {
+        this.articleId = articleId;
+        this.memberId = memberId;
+        this.profileImage = profileImage;
+        this.nickname = nickname;
+        this.content = content;
+        this.likeCnt = likeCnt;
+        this.quoCnt = quoCnt;
+        this.commentCnt = commentCnt;
+        this.bookImage = bookImage;
+        this.title = title;
+        this.author = author;
+        this.articleType = articleType;
+    }
+}

--- a/src/main/java/com/core/book/api/article/dto/ArticleListResponseDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/ArticleListResponseDTO.java
@@ -1,0 +1,18 @@
+package com.core.book.api.article.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ArticleListResponseDTO {
+    private final List<ArticleListDTO> articles; // 게시글 리스트
+    private final boolean isLast; // 마지막 페이지 여부
+    private final int page;       // 현재 페이지 정보
+
+    public ArticleListResponseDTO(List<ArticleListDTO> articles, boolean isLast, int page) {
+        this.articles = articles;
+        this.isLast = isLast;
+        this.page = page;
+    }
+}

--- a/src/main/java/com/core/book/api/article/dto/ReviewArticleListDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/ReviewArticleListDTO.java
@@ -1,5 +1,6 @@
 package com.core.book.api.article.dto;
 
+import com.core.book.api.article.entity.ArticleType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,10 +17,11 @@ public class ReviewArticleListDTO {
     private final String bookImage;
     private final String title;
     private final String author;
+    private final ArticleType articleType;
 
     @Builder
     public ReviewArticleListDTO(Long articleId, Long memberId, String profileImage, String nickname, String content,
-                                long likeCnt, long commentCnt, long quoCnt, String bookImage, String title, String author) {
+                                long likeCnt, long commentCnt, long quoCnt, String bookImage, String title, String author, ArticleType articleType) {
         this.articleId = articleId;
         this.memberId = memberId;
         this.profileImage = profileImage;
@@ -31,5 +33,6 @@ public class ReviewArticleListDTO {
         this.bookImage = bookImage;
         this.title = title;
         this.author = author;
+        this.articleType = articleType;
     }
 }

--- a/src/main/java/com/core/book/api/article/dto/ReviewArticleListResponseDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/ReviewArticleListResponseDTO.java
@@ -8,9 +8,11 @@ import java.util.List;
 public class ReviewArticleListResponseDTO {
     private final List<ReviewArticleListDTO> articles;
     private final boolean isLast;
+    private final int page;
 
-    public ReviewArticleListResponseDTO(List<ReviewArticleListDTO> articles, boolean isLast) {
+    public ReviewArticleListResponseDTO(List<ReviewArticleListDTO> articles, boolean isLast, int page) {
         this.articles = articles;
         this.isLast = isLast;
+        this.page = page;
     }
 }

--- a/src/main/java/com/core/book/api/article/entity/Article.java
+++ b/src/main/java/com/core/book/api/article/entity/Article.java
@@ -1,0 +1,39 @@
+package com.core.book.api.article.entity;
+
+import com.core.book.api.book.entity.Book;
+import com.core.book.api.member.entity.Member;
+import com.core.book.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "article_type")
+public abstract class Article extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ArticleType type;
+
+    private long likeCnt;
+    private long commentCnt;
+    private long quoCnt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    public abstract String getContent();
+    public abstract Member getMember();
+}

--- a/src/main/java/com/core/book/api/article/entity/ReviewArticle.java
+++ b/src/main/java/com/core/book/api/article/entity/ReviewArticle.java
@@ -3,43 +3,27 @@ package com.core.book.api.article.entity;
 import com.core.book.api.article.dto.ReviewArticleCreateDTO;
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.member.entity.Member;
-import com.core.book.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder(toBuilder = true)
+@SuperBuilder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "REVIEW_ARTICLE")
 @AllArgsConstructor
-public class ReviewArticle extends BaseTimeEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "review_article_id")
-    private Long id;
+public class ReviewArticle extends Article {
 
     @Column(columnDefinition = "TEXT")
     private String content; // 게시글 내용
 
-    @Enumerated(EnumType.STRING)
-    private ArticleType type; // 게시글 타입
-
     private String oneLineReview; //한줄평 리뷰
-
-    private long likeCnt; // 좋아요 수
-    private long quoCnt; // 인용 수
-    private long commentCnt; // 댓글 수
     private float starRating; // 평점
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private Member member;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id")
-    private Book book;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "reviewarticle_tag_id")
@@ -58,6 +42,16 @@ public class ReviewArticle extends BaseTimeEntity {
                                 : dto.getReviewArticleTagDTO().toEntity())
                                 : this.reviewArticleTag)
                 .build();
+    }
+
+    @Override
+    public String getContent() {
+        return this.content;
+    }
+
+    @Override
+    public Member getMember() {
+        return this.member;
     }
 
 }

--- a/src/main/java/com/core/book/api/article/repository/ArticleRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/ArticleRepository.java
@@ -1,0 +1,22 @@
+package com.core.book.api.article.repository;
+
+import com.core.book.api.article.entity.Article;
+import com.core.book.api.article.entity.ArticleType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+
+import java.util.List;
+
+@Repository
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    Page<Article> findByType(ArticleType type, Pageable pageable);
+
+    Page<Article> findByTypeIn(Iterable<ArticleType> types, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "book"})
+    Page<Article> findAll(Pageable pageable);
+}

--- a/src/main/java/com/core/book/api/article/repository/ArticleRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/ArticleRepository.java
@@ -17,6 +17,4 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     Page<Article> findByTypeIn(Iterable<ArticleType> types, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"member", "book"})
-    Page<Article> findAll(Pageable pageable);
 }

--- a/src/main/java/com/core/book/api/article/repository/ReviewArticleRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/ReviewArticleRepository.java
@@ -9,12 +9,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReviewArticleRepository extends JpaRepository<ReviewArticle, Long> {
 
     @Query(value = "SELECT ra FROM ReviewArticle ra JOIN FETCH ra.member m JOIN FETCH ra.book b",
             countQuery = "SELECT COUNT(ra) FROM ReviewArticle ra")
     Page<ReviewArticle> findAllWithFetchJoin(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "book"})
+    Page<ReviewArticle> findByTypeIn(List<ArticleType> types, Pageable pageable);
 
     @EntityGraph(attributePaths = {"member", "book"})
     Page<ReviewArticle> findByType(ArticleType type, Pageable pageable);

--- a/src/main/java/com/core/book/api/article/repository/ReviewArticleRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/ReviewArticleRepository.java
@@ -1,15 +1,11 @@
 package com.core.book.api.article.repository;
 
-import com.core.book.api.article.entity.ArticleType;
 import com.core.book.api.article.entity.ReviewArticle;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ReviewArticleRepository extends JpaRepository<ReviewArticle, Long> {
@@ -18,12 +14,4 @@ public interface ReviewArticleRepository extends JpaRepository<ReviewArticle, Lo
             countQuery = "SELECT COUNT(ra) FROM ReviewArticle ra")
     Page<ReviewArticle> findAllWithFetchJoin(Pageable pageable);
 
-    @EntityGraph(attributePaths = {"member", "book"})
-    Page<ReviewArticle> findByTypeIn(List<ArticleType> types, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"member", "book"})
-    Page<ReviewArticle> findByType(ArticleType type, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"member", "book"})
-    Page<ReviewArticle> findAll(Pageable pageable);
 }

--- a/src/main/java/com/core/book/api/article/service/ArticleViewService.java
+++ b/src/main/java/com/core/book/api/article/service/ArticleViewService.java
@@ -1,12 +1,11 @@
 package com.core.book.api.article.service;
 
-import com.core.book.api.article.dto.ReviewArticleDetailDTO;
-import com.core.book.api.article.dto.ReviewArticleListDTO;
-import com.core.book.api.article.dto.ReviewArticleListResponseDTO;
-import com.core.book.api.article.dto.ReviewArticleTagDTO;
+import com.core.book.api.article.dto.*;
+import com.core.book.api.article.entity.Article;
 import com.core.book.api.article.entity.ArticleType;
 import com.core.book.api.article.entity.ReviewArticle;
 import com.core.book.api.article.entity.ReviewArticleTag;
+import com.core.book.api.article.repository.ArticleRepository;
 import com.core.book.api.article.repository.ReviewArticleRepository;
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.member.entity.Member;
@@ -25,38 +24,37 @@ import java.util.stream.Collectors;
 public class ArticleViewService {
 
     private final ReviewArticleRepository reviewArticleRepository;
+    private final ArticleRepository articleRepository;
     private final FollowRepository followRepository;
 
-    public ReviewArticleListResponseDTO getAllArticles(String articleType, int page, int size) {
+    // 전체 게시글을 가져오는 메서드
+    public ArticleListResponseDTO getAllArticles(String articleType, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+
         if ("all".equalsIgnoreCase(articleType)) {
-            // 게시글 타입 설정: REVIEW, PHRASE, QNA
+            // 전체 게시글 타입 설정: REVIEW, PHRASE, QNA
             List<ArticleType> targetTypes = Arrays.asList(ArticleType.REVIEW, ArticleType.PHRASE, ArticleType.QNA);
 
-            // 페이징 및 정렬 정보 설정 - 생성일 기준 내림차순
-            Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-
-            // 데이터베이스에서 지정된 타입의 게시글을 페이징하여 조회
-            Page<ReviewArticle> reviewArticlePage = reviewArticleRepository.findByTypeIn(
-                    targetTypes, pageable);
+            // 지정된 타입의 게시글을 페이징하여 조회
+            Page<Article> articlePage = articleRepository.findByTypeIn(targetTypes, pageable);
 
             // 조회된 게시글을 DTO로 변환하여 리스트에 추가
-            List<ReviewArticleListDTO> articles = reviewArticlePage.getContent().stream()
+            List<ArticleListDTO> articles = articlePage.getContent().stream()
                     .map(this::convertToListDTO)
                     .collect(Collectors.toList());
 
             // 마지막 페이지 여부 확인
-            boolean isLast = reviewArticlePage.isLast();
+            boolean isLast = articlePage.isLast();
 
             // 응답 DTO 생성 및 반환
-            return new ReviewArticleListResponseDTO(articles, isLast, page);
+            return new ArticleListResponseDTO(articles, isLast, page);
         } else {
             // 특정 게시글 타입이 요청된 경우 해당 메서드로 처리
             return getArticlesByType(articleType, page, size);
         }
     }
 
-    private ReviewArticleListResponseDTO getArticlesByType(String articleType, int page, int size) {
-
+    private ArticleListResponseDTO getArticlesByType(String articleType, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         ArticleType type;
 
@@ -68,38 +66,39 @@ public class ArticleViewService {
         }
 
         // 지정된 타입의 게시글을 페이징하여 조회
-        Page<ReviewArticle> reviewArticlePage = reviewArticleRepository.findByType(type, pageable);
+        Page<Article> articlePage = articleRepository.findByType(type, pageable);
 
-        List<ReviewArticleListDTO> articles = reviewArticlePage.getContent().stream()
+        List<ArticleListDTO> articles = articlePage.getContent().stream()
                 .map(this::convertToListDTO)
                 .collect(Collectors.toList());
 
         // 마지막 페이지 여부 확인
-        boolean isLast = reviewArticlePage.isLast();
+        boolean isLast = articlePage.isLast();
 
-        return new ReviewArticleListResponseDTO(articles, isLast, page);
+        return new ArticleListResponseDTO(articles, isLast, page);
     }
 
-    private ReviewArticleListDTO convertToListDTO(ReviewArticle reviewArticle) {
-        Member member = reviewArticle.getMember(); // 작성자 정보
-        Book book = reviewArticle.getBook(); // 책 정보
+    private ArticleListDTO convertToListDTO(Article article) {
+        Member member = article.getMember(); // 작성자 정보
+        Book book = article.getBook(); // 책 정보
 
-        return ReviewArticleListDTO.builder()
-                .articleId(reviewArticle.getId())
+        return ArticleListDTO.builder()
+                .articleId(article.getId())
                 .memberId(member.getId())
                 .profileImage(member.getImageUrl())
                 .nickname(member.getNickname())
-                .content(reviewArticle.getContent())
-                .likeCnt(reviewArticle.getLikeCnt())
-                .commentCnt(reviewArticle.getCommentCnt())
-                .quoCnt(reviewArticle.getQuoCnt())
+                .content(article.getContent())
+                .likeCnt(article.getLikeCnt())
+                .commentCnt(article.getCommentCnt())
+                .quoCnt(article.getQuoCnt())
                 .bookImage(book.getBookImage())
                 .title(book.getTitle())
                 .author(book.getAuthor())
-                .articleType(reviewArticle.getType())
+                .articleType(article.getType())
                 .build();
     }
 
+    // 감상평 게시글 상세 조회 메서드
     public ReviewArticleDetailDTO getReviewArticleDetail(Long id) {
         // 게시글 조회
         ReviewArticle reviewArticle = reviewArticleRepository.findById(id)

--- a/src/main/java/com/core/book/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/core/book/common/entity/BaseTimeEntity.java
@@ -4,13 +4,19 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder(toBuilder = true)
 @Getter
 public abstract class BaseTimeEntity {
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #99

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 게시글 전체 불러오기 로직을 대폭 수정하여 조회타입이 ALL 인 경우 REVIEW, PHRASE, QNA 게시글 가장 최신순으로 불러옵니다.
- 응답시 page 번호와 해당 게시글의 타입도 반환되도록 수정하였습니다. 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/cdb735c4-0d3c-4b8f-babf-028c92eb25f1)
