### PR TITLE
[FEAT] 댓글 등록, 조회, 수정, 삭제 기능 조회 구현

### DIFF
--- a/src/main/java/com/core/book/api/comment/controller/CommentController.java
+++ b/src/main/java/com/core/book/api/comment/controller/CommentController.java
@@ -1,0 +1,59 @@
+package com.core.book.api.comment.controller;
+
+import com.core.book.api.comment.dto.CommentCreateDTO;
+import com.core.book.api.comment.service.CommentService;
+import com.core.book.api.member.service.MemberService;
+import com.core.book.common.exception.NotFoundException;
+import com.core.book.common.response.ApiResponse;
+import com.core.book.common.response.ErrorStatus;
+import com.core.book.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "Comment", description = "댓글 관련 API 입니다.")
+@RestController
+@RequestMapping("/api/v1/comment")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+    private final MemberService memberService;
+
+    @Operation(
+            summary = "게시글 댓글 작성 API",
+            description = "게시글에 댓글을 작성합니다 (대댓글은 parentId(부모 댓글 ID)를 넣어야합니다. 부모 댓글로 등록시 null로 해주세요!)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createComment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid CommentCreateDTO commentCreateDTO
+    ) {
+
+        // Comment 누락시 예외처리
+        if (commentCreateDTO.getComment() == null || commentCreateDTO.getComment().isEmpty()) {
+            throw new NotFoundException(ErrorStatus.MISSING_COMMENT.getMessage());
+        }
+
+        // 게시글 ID 누락시 예외처리
+        if (commentCreateDTO.getArticleId() == null) {
+            throw new NotFoundException(ErrorStatus.MISSING_COMMENT_ARTICLEID.getMessage());
+        }
+
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+        commentService.createComment(commentCreateDTO, userId);
+
+        return ApiResponse.success_only(SuccessStatus.CREATE_COMMENT_SUCCESS);
+    }
+}

--- a/src/main/java/com/core/book/api/comment/controller/CommentController.java
+++ b/src/main/java/com/core/book/api/comment/controller/CommentController.java
@@ -88,9 +88,10 @@ public class CommentController {
 
     @Operation(
             summary = "댓글 수정 API",
-            description = "특정 댓글을 수정하는 API입니다.")
+            description = "게시글에 달린 댓글을 수정합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "댓글 ID가 입력되지 않았습니다. / 댓글이 입력되지 않았습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "수정 권한이 없습니다.")
     })
@@ -100,7 +101,6 @@ public class CommentController {
             @RequestBody CommentUpdateDTO commentUpdateDTO,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-
         //댓글 ID 누락시 예외처리
         if (id == null) {
             throw new NotFoundException(ErrorStatus.MISSING_COMMENT_ID.getMessage());
@@ -115,5 +115,30 @@ public class CommentController {
         commentService.updateComment(id, commentUpdateDTO, userId);
 
         return ApiResponse.success_only(SuccessStatus.MODIFY_COMMENT_SUCCESS);
+    }
+
+    @Operation(
+            summary = "댓글 삭제 API",
+            description = "게시글에 달린 댓글을 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "댓글 ID가 입력되지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "40₩", description = "삭제 권한이 없습니다.")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        //댓글 ID 누락시 예외처리
+        if (id == null) {
+            throw new NotFoundException(ErrorStatus.MISSING_COMMENT_ID.getMessage());
+        }
+
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+        commentService.deleteComment(id, userId);
+
+        return ApiResponse.success_only(SuccessStatus.DELETE_COMMENT_SUCCESS);
     }
 }

--- a/src/main/java/com/core/book/api/comment/controller/CommentController.java
+++ b/src/main/java/com/core/book/api/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.core.book.api.comment.controller;
 
 import com.core.book.api.comment.dto.CommentCreateDTO;
+import com.core.book.api.comment.dto.CommentResponseDTO;
 import com.core.book.api.comment.service.CommentService;
 import com.core.book.api.member.service.MemberService;
 import com.core.book.common.exception.NotFoundException;
@@ -18,6 +19,8 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 @Tag(name = "Comment", description = "댓글 관련 API 입니다.")
 @RestController
 @RequestMapping("/api/v1/comment")
@@ -33,7 +36,8 @@ public class CommentController {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 등록 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "댓글이 입력되지 않았습니다. / 게시글 ID가 입력되지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없습니다. / 부모 댓글을 찾을 수 없습니다.")
     })
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createComment(
@@ -55,5 +59,29 @@ public class CommentController {
         commentService.createComment(commentCreateDTO, userId);
 
         return ApiResponse.success_only(SuccessStatus.CREATE_COMMENT_SUCCESS);
+    }
+
+    @Operation(
+            summary = "게시글 댓글 조회 API",
+            description = "게시글에 달린 댓글을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "게시글 ID가 입력되지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없습니다.")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CommentResponseDTO>>> getCommentsByArticleId(
+            @RequestParam Long articleId
+    ) {
+
+        // 게시글 ID 누락시 예외처리
+        if (articleId == null) {
+            throw new NotFoundException(ErrorStatus.MISSING_COMMENT_ARTICLEID.getMessage());
+        }
+
+        List<CommentResponseDTO> comments = commentService.getCommentsByArticleId(articleId);
+
+        return ApiResponse.success(SuccessStatus.GET_COMMENT_SUCCESS, comments);
     }
 }

--- a/src/main/java/com/core/book/api/comment/controller/CommentController.java
+++ b/src/main/java/com/core/book/api/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.core.book.api.comment.controller;
 
 import com.core.book.api.comment.dto.CommentCreateDTO;
 import com.core.book.api.comment.dto.CommentResponseDTO;
+import com.core.book.api.comment.dto.CommentUpdateDTO;
 import com.core.book.api.comment.service.CommentService;
 import com.core.book.api.member.service.MemberService;
 import com.core.book.common.exception.NotFoundException;
@@ -83,5 +84,36 @@ public class CommentController {
         List<CommentResponseDTO> comments = commentService.getCommentsByArticleId(articleId);
 
         return ApiResponse.success(SuccessStatus.GET_COMMENT_SUCCESS, comments);
+    }
+
+    @Operation(
+            summary = "댓글 수정 API",
+            description = "특정 댓글을 수정하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "수정 권한이 없습니다.")
+    })
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> updateComment(
+            @PathVariable Long id,
+            @RequestBody CommentUpdateDTO commentUpdateDTO,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+
+        //댓글 ID 누락시 예외처리
+        if (id == null) {
+            throw new NotFoundException(ErrorStatus.MISSING_COMMENT_ID.getMessage());
+        }
+
+        // Comment 누락시 예외처리
+        if (commentUpdateDTO.getComment() == null || commentUpdateDTO.getComment().isEmpty()) {
+            throw new NotFoundException(ErrorStatus.MISSING_COMMENT.getMessage());
+        }
+
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+        commentService.updateComment(id, commentUpdateDTO, userId);
+
+        return ApiResponse.success_only(SuccessStatus.MODIFY_COMMENT_SUCCESS);
     }
 }

--- a/src/main/java/com/core/book/api/comment/dto/CommentCreateDTO.java
+++ b/src/main/java/com/core/book/api/comment/dto/CommentCreateDTO.java
@@ -1,7 +1,5 @@
 package com.core.book.api.comment.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/core/book/api/comment/dto/CommentCreateDTO.java
+++ b/src/main/java/com/core/book/api/comment/dto/CommentCreateDTO.java
@@ -1,0 +1,15 @@
+package com.core.book.api.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentCreateDTO {
+
+    private String comment;
+    private Long articleId;
+    private Long parentId;
+}

--- a/src/main/java/com/core/book/api/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/com/core/book/api/comment/dto/CommentResponseDTO.java
@@ -1,0 +1,32 @@
+package com.core.book.api.comment.dto;
+
+import com.core.book.api.comment.entity.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class CommentResponseDTO {
+
+    private Long id;
+    private String comment;
+    private String nickname;
+    private String profileImageUrl;
+    private Long parentId;
+    private String updatedAt;
+
+    public static CommentResponseDTO fromEntity(Comment comment) {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss");
+
+        return CommentResponseDTO.builder()
+                .id(comment.getId())
+                .comment(comment.getComment())
+                .nickname(comment.getMember().getNickname())
+                .profileImageUrl(comment.getMember().getImageUrl())
+                .parentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
+                .updatedAt(comment.getUpdatedAt().format(dateTimeFormatter))
+                .build();
+    }
+}

--- a/src/main/java/com/core/book/api/comment/dto/CommentUpdateDTO.java
+++ b/src/main/java/com/core/book/api/comment/dto/CommentUpdateDTO.java
@@ -1,0 +1,15 @@
+package com.core.book.api.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentUpdateDTO {
+
+    private String comment;
+}

--- a/src/main/java/com/core/book/api/comment/entity/Comment.java
+++ b/src/main/java/com/core/book/api/comment/entity/Comment.java
@@ -1,0 +1,40 @@
+package com.core.book.api.comment.entity;
+
+import com.core.book.api.article.entity.Article;
+import com.core.book.api.member.entity.Member;
+import com.core.book.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "comment")
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parentComment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Member member;
+}

--- a/src/main/java/com/core/book/api/comment/repository/CommentRepository.java
+++ b/src/main/java/com/core/book/api/comment/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package com.core.book.api.comment.repository;
 
+import com.core.book.api.article.entity.Article;
 import com.core.book.api.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByArticle(Article article);
 }

--- a/src/main/java/com/core/book/api/comment/repository/CommentRepository.java
+++ b/src/main/java/com/core/book/api/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.core.book.api.comment.repository;
+
+import com.core.book.api.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/core/book/api/comment/service/CommentService.java
+++ b/src/main/java/com/core/book/api/comment/service/CommentService.java
@@ -82,4 +82,18 @@ public class CommentService {
 
         commentRepository.save(comment);
     }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        // 댓글을 ID로 찾고, 존재하지 않으면 예외 처리
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.COMMENT_NOT_FOUND_EXCPETION.getMessage()));
+
+        // 해당 댓글의 작성자가 요청한 사용자와 동일한지 검증
+        if (!comment.getMember().getId().equals(userId)) {
+            throw new UnauthorizedException(ErrorStatus.INVALID_DELETE_AUTH.getMessage());
+        }
+
+        commentRepository.delete(comment);
+    }
 }

--- a/src/main/java/com/core/book/api/comment/service/CommentService.java
+++ b/src/main/java/com/core/book/api/comment/service/CommentService.java
@@ -4,11 +4,13 @@ import com.core.book.api.article.entity.Article;
 import com.core.book.api.article.repository.ArticleRepository;
 import com.core.book.api.comment.dto.CommentCreateDTO;
 import com.core.book.api.comment.dto.CommentResponseDTO;
+import com.core.book.api.comment.dto.CommentUpdateDTO;
 import com.core.book.api.comment.entity.Comment;
 import com.core.book.api.comment.repository.CommentRepository;
 import com.core.book.api.member.entity.Member;
 import com.core.book.api.member.repository.MemberRepository;
 import com.core.book.common.exception.NotFoundException;
+import com.core.book.common.exception.UnauthorizedException;
 import com.core.book.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -61,5 +63,23 @@ public class CommentService {
         return comments.stream()
                 .map(CommentResponseDTO::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updateComment(Long commentId, CommentUpdateDTO commentUpdateDTO, Long userId) {
+        // 댓글이 존재하지 않으면 예외 처리
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.COMMENT_NOT_FOUND_EXCPETION.getMessage()));
+
+        // 해당 댓글의 작성자가 요청한 사용자와 동일한지 검증
+        if (!comment.getMember().getId().equals(userId)) {
+            throw new UnauthorizedException(ErrorStatus.INVALID_MODIFY_AUTH.getMessage());
+        }
+
+        comment = comment.toBuilder()
+                .comment(commentUpdateDTO.getComment())
+                .build();
+
+        commentRepository.save(comment);
     }
 }

--- a/src/main/java/com/core/book/api/comment/service/CommentService.java
+++ b/src/main/java/com/core/book/api/comment/service/CommentService.java
@@ -1,0 +1,46 @@
+package com.core.book.api.comment.service;
+
+import com.core.book.api.article.entity.Article;
+import com.core.book.api.article.repository.ArticleRepository;
+import com.core.book.api.comment.dto.CommentCreateDTO;
+import com.core.book.api.comment.entity.Comment;
+import com.core.book.api.comment.repository.CommentRepository;
+import com.core.book.api.member.entity.Member;
+import com.core.book.api.member.repository.MemberRepository;
+import com.core.book.common.exception.NotFoundException;
+import com.core.book.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+
+    public Comment createComment(CommentCreateDTO commentCreateDTO, Long userId) {
+        // 해당 유저를 찾을 수 없을 경우 예외처리
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+        // 해당 게시글을 찾을 수 없을 경우 예외처리
+        Article article = articleRepository.findById(commentCreateDTO.getArticleId())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.ARTICLE_NOT_FOUND_EXCEPTION.getMessage()));
+        // 부모댓글 처리
+        Comment parentComment = null;
+        if (commentCreateDTO.getParentId() != null) {
+            parentComment = commentRepository.findById(commentCreateDTO.getParentId())
+                    .orElseThrow(() -> new NotFoundException(ErrorStatus.PARENT_COMMENT_NOT_FOUND_EXCEPTION.getMessage()));
+        }
+
+        Comment comment = Comment.builder()
+                .comment(commentCreateDTO.getComment())
+                .article(article)
+                .member(member)
+                .parentComment(parentComment)
+                .build();
+
+        return commentRepository.save(comment);
+    }
+}

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -36,6 +36,7 @@ public enum ErrorStatus {
     ARTICLE_TYPE_NOT_FOUND_EXCEPTION(HttpStatus.BAD_REQUEST, "게시글 타입이 존재하지 않습니다."),
     MISSING_COMMENT(HttpStatus.BAD_REQUEST, "댓글이 입력되지 않았습니다."),
     MISSING_COMMENT_ARTICLEID(HttpStatus.BAD_REQUEST, "게시글 ID가 입력되지 않았습니다."),
+    MISSING_COMMENT_ID(HttpStatus.BAD_REQUEST,"댓글 ID가 입력되지 않았습니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -43,6 +44,7 @@ public enum ErrorStatus {
     USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"인증되지 않은 사용자입니다."),
     INVALID_KAKAO_ACCESSTOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 카카오 엑세스토큰입니다."),
     INVALID_REFRESHTOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시토큰입니다."),
+    INVALID_MODIFY_AUTH(HttpStatus.UNAUTHORIZED,"수정 권한이 없습니다."),
 
     /**
      * 404 NOT_FOUND
@@ -58,6 +60,7 @@ public enum ErrorStatus {
     READBOOK_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서를 읽은 기록이 없습니다."),
     ARTICLE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"게시글을 찾을 수 없습니다."),
     PARENT_COMMENT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"부모 댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND_EXCPETION(HttpStatus.NOT_FOUND,"댓글을 찾을 수 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -34,6 +34,8 @@ public enum ErrorStatus {
     ARTICLE_MODIFY_NOT_SAME_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "게시글 작성자와 수정 요청자가 다릅니다."),
     ARTICLE_DELETE_NOT_SAME_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "게시글 작성자와 삭제 요청자가 다릅니다."),
     ARTICLE_TYPE_NOT_FOUND_EXCEPTION(HttpStatus.BAD_REQUEST, "게시글 타입이 존재하지 않습니다."),
+    MISSING_COMMENT(HttpStatus.BAD_REQUEST, "댓글이 입력되지 않았습니다."),
+    MISSING_COMMENT_ARTICLEID(HttpStatus.BAD_REQUEST, "게시글 ID가 입력되지 않았습니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -55,6 +57,7 @@ public enum ErrorStatus {
     INFOOPEN_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "사용자 정보 공개 동의 여부가 등록되어 있지 않습니다."),
     READBOOK_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 도서를 읽은 기록이 없습니다."),
     ARTICLE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"게시글을 찾을 수 없습니다."),
+    PARENT_COMMENT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND,"부모 댓글을 찾을 수 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -45,6 +45,7 @@ public enum ErrorStatus {
     INVALID_KAKAO_ACCESSTOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 카카오 엑세스토큰입니다."),
     INVALID_REFRESHTOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시토큰입니다."),
     INVALID_MODIFY_AUTH(HttpStatus.UNAUTHORIZED,"수정 권한이 없습니다."),
+    INVALID_DELETE_AUTH(HttpStatus.UNAUTHORIZED,"삭제 권한이 없습니다."),
 
     /**
      * 404 NOT_FOUND

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -50,6 +50,7 @@ public enum SuccessStatus {
     CREATE_ARTICLE_SUCCESS(HttpStatus.CREATED, "게시판 등록 성공"),
     CREATE_USERTAG_SUCCESS(HttpStatus.CREATED, "USERTAG 등록 성공"),
     CREATE_BOOKSHELF_SUCCESS(HttpStatus.CREATED, "책장 등록 성공"),
+    CREATE_COMMENT_SUCCESS(HttpStatus.CREATED, "댓글 등록 성공"),
 
     ;
 

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -45,6 +45,7 @@ public enum SuccessStatus {
     DELETE_ARTICLE_SUCCESS(HttpStatus.OK, "게시글 삭제 성공"),
 
     GET_COMMENT_SUCCESS(HttpStatus.OK, "댓글 조회 성공"),
+    MODIFY_COMMENT_SUCCESS(HttpStatus.OK,"댓글 수정 성공"),
 
     /**
      * 201

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -44,6 +44,8 @@ public enum SuccessStatus {
     MODIFY_ARTICLE_SUCCESS(HttpStatus.OK, "게시글 수정 성공"),
     DELETE_ARTICLE_SUCCESS(HttpStatus.OK, "게시글 삭제 성공"),
 
+    GET_COMMENT_SUCCESS(HttpStatus.OK, "댓글 조회 성공"),
+
     /**
      * 201
      */

--- a/src/main/java/com/core/book/common/response/SuccessStatus.java
+++ b/src/main/java/com/core/book/common/response/SuccessStatus.java
@@ -46,6 +46,7 @@ public enum SuccessStatus {
 
     GET_COMMENT_SUCCESS(HttpStatus.OK, "댓글 조회 성공"),
     MODIFY_COMMENT_SUCCESS(HttpStatus.OK,"댓글 수정 성공"),
+    DELETE_COMMENT_SUCCESS(HttpStatus.OK,"댓글 삭제 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #100

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 댓글 작성,조회,수정,삭제 API를 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 댓글 삭제 기능 에서 자식댓글이 존재하고있을 때 부모댓글 삭제 시도시 어떻게 처리해야할지 의논해야합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
(댓글 작성)
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/73782aca-6f07-4dfb-be02-3f586d6e94dc">

(댓글 조회)
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/303a1c55-27b1-48b6-a28c-45592b00c554">

(댓글 수정)
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/428ff0e0-c105-4f0c-9f9f-74ef9a7f70a4">

(댓글 삭제)
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/e80df7a8-696e-4608-bd2c-4b0884c8231b">
