### PR TITLE
[FIX] 책장 전체 조회 API - 응답에 읽은 책의 id 값 추가하기 & userId 코드 컨벤션 수정

### DIFF
--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBooksDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBooksDTO.java
@@ -3,7 +3,6 @@ package com.core.book.api.bookshelf.dto;
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.bookshelf.entity.ReadBooks;
 import com.core.book.api.bookshelf.entity.ReadBooksTag;
-import com.core.book.api.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,15 +17,12 @@ public class ReadBooksDTO {
     private String oneLineReview; // 한줄평
     private ReadBooksTagDTO readBooksTag; //태그
 
-    private Long memberId; // 회원 ID
-
-    public ReadBooks toEntity(Book book, Member member, ReadBooksTag readBooksTag){
+    public ReadBooks toEntity(Book book, ReadBooksTag readBooksTag){
         return ReadBooks.builder()
                 .readDate(this.readDate)
                 .starRating(this.starRating)
                 .oneLineReview(this.oneLineReview)
                 .book(book)
-                .member(member)
                 .readBooksTag(readBooksTag)
                 .build();
     }

--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBookshelfResponseDTO.java
@@ -26,7 +26,8 @@ public class ReadBookshelfResponseDTO {
         @Getter
         public static class MonthlyReadBookDTO {
 
-            private String isbn; //isbn
+            private Long id;
+            private String isbn; // isbn
             private String bookImage; // 책 이미지
             private double starRating; // 평점
             private String title; // 책 제목

--- a/src/main/java/com/core/book/api/bookshelf/dto/WishBooksDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/WishBooksDTO.java
@@ -2,7 +2,6 @@ package com.core.book.api.bookshelf.dto;
 
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.bookshelf.entity.WishBooks;
-import com.core.book.api.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,13 +11,10 @@ public class WishBooksDTO {
 
     private String reason; // 읽고 싶은 이유
 
-    private Long memberId; // 회원 ID
-
-    public WishBooks toEntity(Book book, Member member){
+    public WishBooks toEntity(Book book){
         return WishBooks.builder()
                 .reason(this.reason)
                 .book(book)
-                .member(member)
                 .build();
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #123 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 책장 전체 조회 API 응답에 읽은 책의 id 값을 추가하였습니다. 이를 통해 프론트 단에서 id 값으로 상세 정보 조회 및 수정 시 사용할 수 있습니다.
- userId 코드 컨벤션 수정하였습니다. 기존 userId를 프론트 단에서 받는 로직에서 토큰 인증으로 인증 로직을 수정하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
userId 토큰 인증 로직 ->
![image](https://github.com/user-attachments/assets/92d45edf-9075-4881-b555-cc0c08b199d4)
