### PR TITLE
[FIX] 책장 수정/삭제 API - 타 사용자 수정/삭제 예외처리

### DIFF
--- a/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
+++ b/src/main/java/com/core/book/api/bookshelf/controller/BookshelfController.java
@@ -184,14 +184,17 @@ public class BookshelfController {
     })
     @PatchMapping("/api/v1/bookshelf/read/{id}")
     public ResponseEntity<ApiResponse<Void>> updateReadBookshelf(
-            @RequestBody ReadBooksDTO readBooksDTO, @PathVariable Long id){
+            @RequestBody ReadBooksDTO readBooksDTO, @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails){
 
         // 예외 처리 : 등록 날짜가 입력되지 않은 경우
         if(readBooksDTO.getReadDate() == null){
             throw new NotFoundException(ErrorStatus.MISSING_BOOKSHELF_DATE.getMessage());
         }
 
-        bookShelfService.updateReadBookshelf(readBooksDTO, id);
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+
+        bookShelfService.updateReadBookshelf(readBooksDTO, id, userId);
 
         return ApiResponse.success_only(SuccessStatus.UPDATE_BOOKSHELF_INFO_SUCCESS);
     }
@@ -205,9 +208,13 @@ public class BookshelfController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 책장에서 선택된 도서를 찾을 수 없습니다.")
     })
     @PatchMapping("/api/v1/bookshelf/wish/{id}")
-    public ResponseEntity<ApiResponse<Void>> updateWishBookshelf(@RequestBody WishBooksDTO wishBooksDTO, @PathVariable Long id){
+    public ResponseEntity<ApiResponse<Void>> updateWishBookshelf(
+            @RequestBody WishBooksDTO wishBooksDTO, @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails){
 
-        bookShelfService.updateWishBookshelf(wishBooksDTO, id);
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+
+        bookShelfService.updateWishBookshelf(wishBooksDTO, id, userId);
 
         return ApiResponse.success_only(SuccessStatus.UPDATE_BOOKSHELF_INFO_SUCCESS);
     }
@@ -227,9 +234,13 @@ public class BookshelfController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 책장에서 선택된 도서를 찾을 수 없습니다.")
     })
     @DeleteMapping("/api/v1/bookshelf/read/{id}")
-    public ResponseEntity<ApiResponse<Void>> deleteReadBookshelf(@PathVariable Long id){
+    public ResponseEntity<ApiResponse<Void>> deleteReadBookshelf(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails){
 
-        bookShelfService.deleteReadBookshelf(id);
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+
+        bookShelfService.deleteReadBookshelf(id, userId);
 
         return ApiResponse.success_only(SuccessStatus.DELETE_BOOKSHELF_SUCCESS);
     }
@@ -243,9 +254,13 @@ public class BookshelfController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 책장에서 선택된 도서를 찾을 수 없습니다.")
     })
     @DeleteMapping("/api/v1/bookshelf/wish/{id}")
-    public ResponseEntity<ApiResponse<Void>> deleteWishBookshelf(@PathVariable Long id){
+    public ResponseEntity<ApiResponse<Void>> deleteWishBookshelf(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails){
 
-        bookShelfService.deleteWishBookshelf(id);
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+
+        bookShelfService.deleteWishBookshelf(id, userId);
 
         return ApiResponse.success_only(SuccessStatus.DELETE_BOOKSHELF_SUCCESS);
     }

--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBooksDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBooksDTO.java
@@ -4,13 +4,17 @@ import com.core.book.api.book.entity.Book;
 import com.core.book.api.bookshelf.entity.ReadBooks;
 import com.core.book.api.bookshelf.entity.ReadBooksTag;
 import com.core.book.api.member.entity.Member;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ReadBooksDTO {
 
     private LocalDate readDate; // 읽은 날짜

--- a/src/main/java/com/core/book/api/bookshelf/dto/ReadBooksDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/ReadBooksDTO.java
@@ -3,6 +3,7 @@ package com.core.book.api.bookshelf.dto;
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.bookshelf.entity.ReadBooks;
 import com.core.book.api.bookshelf.entity.ReadBooksTag;
+import com.core.book.api.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,12 +18,13 @@ public class ReadBooksDTO {
     private String oneLineReview; // 한줄평
     private ReadBooksTagDTO readBooksTag; //태그
 
-    public ReadBooks toEntity(Book book, ReadBooksTag readBooksTag){
+    public ReadBooks toEntity(Book book, Member member, ReadBooksTag readBooksTag){
         return ReadBooks.builder()
                 .readDate(this.readDate)
                 .starRating(this.starRating)
                 .oneLineReview(this.oneLineReview)
                 .book(book)
+                .member(member)
                 .readBooksTag(readBooksTag)
                 .build();
     }

--- a/src/main/java/com/core/book/api/bookshelf/dto/WishBooksDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/WishBooksDTO.java
@@ -2,6 +2,7 @@ package com.core.book.api.bookshelf.dto;
 
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.bookshelf.entity.WishBooks;
+import com.core.book.api.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,10 +12,11 @@ public class WishBooksDTO {
 
     private String reason; // 읽고 싶은 이유
 
-    public WishBooks toEntity(Book book){
+    public WishBooks toEntity(Book book, Member member){
         return WishBooks.builder()
                 .reason(this.reason)
                 .book(book)
+                .member(member)
                 .build();
     }
 }

--- a/src/main/java/com/core/book/api/bookshelf/dto/WishBooksDTO.java
+++ b/src/main/java/com/core/book/api/bookshelf/dto/WishBooksDTO.java
@@ -3,11 +3,15 @@ package com.core.book.api.bookshelf.dto;
 import com.core.book.api.book.entity.Book;
 import com.core.book.api.bookshelf.entity.WishBooks;
 import com.core.book.api.member.entity.Member;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class WishBooksDTO {
 
     private String reason; // 읽고 싶은 이유

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -37,6 +37,8 @@ public enum ErrorStatus {
     MISSING_COMMENT(HttpStatus.BAD_REQUEST, "댓글이 입력되지 않았습니다."),
     MISSING_COMMENT_ARTICLEID(HttpStatus.BAD_REQUEST, "게시글 ID가 입력되지 않았습니다."),
     MISSING_COMMENT_ID(HttpStatus.BAD_REQUEST,"댓글 ID가 입력되지 않았습니다."),
+    BOOKSHELF_MODIFY_NOT_SAME_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "책장 소유자와 수정 요청자가 다릅니다."),
+    BOOKSHELF_DELETE_NOT_SAME_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "책장 소유자와 삭제 요청자가 다릅니다."),
 
     /**
      * 401 UNAUTHORIZED


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #125 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 책장 상세 정보 수정 API 에 '책장 소유자와 수정 요청자가 다른 경우' 예외 처리를 구현하였습니다.
- 책장 삭제 API 에 '책장 소유자와 삭제 요청자가 다른 경우' 예외 처리를 구현하였습니다.
- 이전 userId 코드 컨벤션을 구현하다 책장 등록 시 memberId 를 저장하는 코드를 삭제하는 오류를 범하여 이를 수정하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
'책장 소유자와 수정 요청자가 다른 경우' 예외처리 ->
![image](https://github.com/user-attachments/assets/74c7e0c3-0b0b-4b98-a259-0f1ed93834c5)

'책장 소유자와 삭제 요청자가 다른 경우' 예외처리 ->
![image](https://github.com/user-attachments/assets/6a186cf6-1d2e-483e-b220-24a45f33717d)
