### PR TITLE
[FIX] 읽은 책 책장 API - 책 태그 수정 오류 및 NULL 저장 오류 해결

### DIFF
--- a/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
+++ b/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
@@ -219,6 +219,11 @@ public class BookShelfService {
 
         ReadBooksTag readBooksTag = readBooks.getReadBooksTag();
 
+        // 태그가 입력된 것이 없을 경우, null 반환
+        if(readBooksTag == null){
+            return convertToReadBooksDTO(readBooks, null);
+        }
+
         ReadBooksDTO.ReadBooksTagDTO tagDTO = convertToReadBooksTagDTO(readBooksTag);
 
         return convertToReadBooksDTO(readBooks, tagDTO);
@@ -389,6 +394,9 @@ public class BookShelfService {
                     .build();
         } else if(readBooksTag == null && tagDTO != null){
             readBooksTag = tagDTO.toEntity();
+        }
+
+        if(readBooksTag != null){
             readBooksTagRepository.save(readBooksTag); // 새로운 태그 저장
         }
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #130 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 읽은 책 책장 상세 정보 조회 API에서, 초기 책장(read) 등록 시 태그 저장이 안된 경우(NULL) 상세 정보 조회가 NULL로 조회되지 않고 오류가 나는 문제를 해결하였습니다.
- 읽은 책 책장 상세 정보 수정 API에서, 책 태그 수정만 반영이 안되는 오류를 해결하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
책 상세 정보 수정 - 태그 수정 성공 ->
![image](https://github.com/user-attachments/assets/9e70ddd5-8414-462f-986a-74f312336045)

책 태그가 없을 경우, 응답 출력 ->
![image](https://github.com/user-attachments/assets/66f02aff-5e8f-4fc9-aa04-c93952e8679c)


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
