### PR TITLE
[FIX] 회원가입 로직(닉네임 체크) 수정

### DIFF
--- a/src/main/java/com/core/book/api/member/controller/MemberController.java
+++ b/src/main/java/com/core/book/api/member/controller/MemberController.java
@@ -163,7 +163,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "수정할 프로필 이미지파일이 업로드 되지 않았습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "프로필 사진이 변경되지 않았습니다.")
     })
-    @PutMapping(value = "/change-profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/change-profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> changeProfileImage(@AuthenticationPrincipal UserDetails userDetails,
                                                                 @RequestParam("image") MultipartFile image) {
         Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
@@ -189,7 +189,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "닉네임이 입력되지 않았습니다."),
     })
-    @PutMapping("/change-nickname")
+    @PatchMapping("/change-nickname")
     public ResponseEntity<ApiResponse<Void>> changeNickname(@AuthenticationPrincipal UserDetails userDetails,
                                                             @RequestParam("nickname") String nickname) {
         Long userId = memberService.getUserIdByEmail(userDetails.getUsername());

--- a/src/main/java/com/core/book/api/member/service/MemberService.java
+++ b/src/main/java/com/core/book/api/member/service/MemberService.java
@@ -124,10 +124,6 @@ public class MemberService {
 
         userTagRepository.save(userTag);
 
-        // 유저 권한 설정 GUEST -> USER
-        Member updatedMember = member.authorizeUser();
-        memberRepository.save(updatedMember);
-
     }
 
     private void validateTagRequest(UserTagRequestDTO userTagRequest) {
@@ -215,6 +211,12 @@ public class MemberService {
 
         Member updatedMember = member.updateNickname(nickname);
         memberRepository.save(updatedMember); // Member 객체 반환
+
+        // 초기 회원가입시 최종 닉네임 등록 후 USER로 승격
+        if (Role.GUEST.equals(member.getRole())) {
+            Member updatedRole = member.authorizeUser();
+            memberRepository.save(updatedRole);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #138

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원가입시 GUEST 에서 USER로 승격되는 시점을 변경하였습니다. (처음 카카오 로그인 시도 후 최종 닉네임 변경이 진행되어야 일반유저(Role.USER)로 전환)
- 프로필사진 변경, 닉네임 변경 컨트롤러 매핑을 수정하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
![image](https://github.com/user-attachments/assets/59d89901-b562-4e14-89ef-586bc292dea4)
