### PR TITLE
[FEAT] 인용 게시글 등록,수정,삭제,조회 기능 구현

### DIFF
--- a/src/main/java/com/core/book/api/article/controller/ArticleController.java
+++ b/src/main/java/com/core/book/api/article/controller/ArticleController.java
@@ -1,8 +1,14 @@
 package com.core.book.api.article.controller;
 
+import com.core.book.api.article.dto.QuotationArticleListResponseDTO;
+import com.core.book.api.article.entity.Article;
+import com.core.book.api.article.repository.ArticleRepository;
 import com.core.book.api.article.service.ArticleService;
+import com.core.book.api.article.service.ArticleViewService;
 import com.core.book.api.member.service.MemberService;
+import com.core.book.common.exception.NotFoundException;
 import com.core.book.common.response.ApiResponse;
+import com.core.book.common.response.ErrorStatus;
 import com.core.book.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -21,6 +27,8 @@ public class ArticleController {
 
     private final MemberService memberService;
     private final ArticleService articleService;
+    private final ArticleRepository articleRepository;
+    private final ArticleViewService articleViewService;
 
     @Operation(
             summary = "게시글 좋아요 토글 API",
@@ -39,5 +47,24 @@ public class ArticleController {
         Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
         articleService.toggleLike(id, userId);
         return ApiResponse.success_only(SuccessStatus.TOGGLE_LIKE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "인용 게시글 목록 조회 API",
+            description = "원 게시글의 id를 기반으로 인용 게시글 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인용 게시글 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없습니다.")
+    })
+    @GetMapping("/{articleId}/quotations")
+    public ResponseEntity<ApiResponse<QuotationArticleListResponseDTO>> getQuotationArticlesForArticle(
+            @PathVariable Long articleId,
+            @RequestParam int page,
+            @RequestParam int size
+    ) {
+
+        QuotationArticleListResponseDTO dto = articleViewService.getQuotationArticlesByQuotedArticleId(articleId, page, size);
+        return ApiResponse.success(SuccessStatus.GET_ARTICLE_LIST_SUCCESS, dto);
     }
 }

--- a/src/main/java/com/core/book/api/article/controller/ArticleCreateController.java
+++ b/src/main/java/com/core/book/api/article/controller/ArticleCreateController.java
@@ -2,6 +2,7 @@ package com.core.book.api.article.controller;
 
 import com.core.book.api.article.dto.PhraseArticleCreateDTO;
 import com.core.book.api.article.dto.QnaArticleCreateDTO;
+import com.core.book.api.article.dto.QuotationArticleCreateDTO;
 import com.core.book.api.article.dto.ReviewArticleCreateDTO;
 import com.core.book.api.article.service.ArticleCreateService;
 import com.core.book.api.member.service.MemberService;
@@ -129,6 +130,29 @@ public class ArticleCreateController {
 
         Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
         articleCreateService.createQnaArticle(qnaArticleCreateDTO, userId);
+
+        return ApiResponse.success_only(SuccessStatus.CREATE_ARTICLE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "인용 게시글 생성 API",
+            description = "감상평 게시글을 인용하는 인용 게시글을 생성합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "게시글 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "게시글이 존재하지 않습니다.")
+    })
+    @PostMapping("/quotation")
+    public ResponseEntity<ApiResponse<Void>> createQuotationArticle(
+            @RequestBody QuotationArticleCreateDTO quotationArticleCreateDTO,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        if (quotationArticleCreateDTO.getContent() == null || quotationArticleCreateDTO.getContent().isEmpty()) {
+            throw new NotFoundException(ErrorStatus.VALIDATION_CONTENT_MISSING_EXCEPTION.getMessage());
+        }
+
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+        articleCreateService.createQuotationArticle(quotationArticleCreateDTO, userId);
 
         return ApiResponse.success_only(SuccessStatus.CREATE_ARTICLE_SUCCESS);
     }

--- a/src/main/java/com/core/book/api/article/controller/ArticleDeleteController.java
+++ b/src/main/java/com/core/book/api/article/controller/ArticleDeleteController.java
@@ -82,4 +82,24 @@ public class ArticleDeleteController {
         return ApiResponse.success_only(SuccessStatus.DELETE_ARTICLE_SUCCESS);
     }
 
+    @Operation(
+            summary = "인용 게시글 삭제 API",
+            description = "인용 게시글을 삭제합니다. (TYPE : QUOTATION)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "게시글 작성자와 삭제 요청자가 다릅니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없습니다.")
+    })
+    @DeleteMapping("/quotation/{QuoatationArticleId}")
+    public ResponseEntity<ApiResponse<Void>> deleteQuotationArticle(
+            @PathVariable Long QuoatationArticleId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+        articleDeleteService.deleteQuotationArticle(QuoatationArticleId, userId);
+
+        return ApiResponse.success_only(SuccessStatus.DELETE_ARTICLE_SUCCESS);
+    }
+
 }

--- a/src/main/java/com/core/book/api/article/controller/ArticleModifyController.java
+++ b/src/main/java/com/core/book/api/article/controller/ArticleModifyController.java
@@ -2,6 +2,7 @@ package com.core.book.api.article.controller;
 
 import com.core.book.api.article.dto.PhraseArticleCreateDTO;
 import com.core.book.api.article.dto.QnaArticleCreateDTO;
+import com.core.book.api.article.dto.QuotationArticleModifyDTO;
 import com.core.book.api.article.dto.ReviewArticleCreateDTO;
 import com.core.book.api.article.service.ArticleModifyService;
 import com.core.book.api.member.service.MemberService;
@@ -95,6 +96,30 @@ public class ArticleModifyController {
 
         Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
         articleModifyService.modifyQnaArticle(id, qnaArticleCreateDTO, userId);
+
+        return ApiResponse.success_only(SuccessStatus.MODIFY_ARTICLE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "인용 게시글 수정 API",
+            description = "인용 게시글을 수정합니다. (TYPE : QUOTATION)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "게시글 작성자와 수정 요청자가 다릅니다.")
+    })
+    @PutMapping("/quotation/{QuoatationArticleId}")
+    public ResponseEntity<ApiResponse<Void>> modifyQuotationArticle(
+            @PathVariable Long QuoatationArticleId,
+            @RequestBody QuotationArticleModifyDTO quotationArticleModifyDTO,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        if (quotationArticleModifyDTO.getContent() == null || quotationArticleModifyDTO.getContent().isEmpty()) {
+            throw new NotFoundException(ErrorStatus.VALIDATION_CONTENT_MISSING_EXCEPTION.getMessage());
+        }
+
+        Long userId = memberService.getUserIdByEmail(userDetails.getUsername());
+        articleModifyService.modifyQuotationArticle(QuoatationArticleId, quotationArticleModifyDTO, userId);
 
         return ApiResponse.success_only(SuccessStatus.MODIFY_ARTICLE_SUCCESS);
     }

--- a/src/main/java/com/core/book/api/article/controller/ArticleViewController.java
+++ b/src/main/java/com/core/book/api/article/controller/ArticleViewController.java
@@ -1,9 +1,6 @@
 package com.core.book.api.article.controller;
 
-import com.core.book.api.article.dto.ArticleListResponseDTO;
-import com.core.book.api.article.dto.PhraseArticleDetailDTO;
-import com.core.book.api.article.dto.QnaArticleDetailDTO;
-import com.core.book.api.article.dto.ReviewArticleDetailDTO;
+import com.core.book.api.article.dto.*;
 import com.core.book.api.article.service.ArticleViewService;
 import com.core.book.common.response.ApiResponse;
 import com.core.book.common.response.SuccessStatus;
@@ -86,6 +83,26 @@ public class ArticleViewController {
                                                                                 @AuthenticationPrincipal UserDetails userDetails) {
         QnaArticleDetailDTO qnaArticleDetailDTO = articleViewService.getQnaArticleDetail(id,userDetails);
         return ApiResponse.success(SuccessStatus.GET_ARTICLE_SUCCESS, qnaArticleDetailDTO);
+    }
+
+    @Operation(
+            summary = "인용 게시글 목록 조회 API",
+            description = "감상평 게시글의 id를 기반으로 인용 게시글 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없습니다.")
+    })
+    @GetMapping("/quotation/{reviewArticleId}")
+    public ResponseEntity<ApiResponse<QuotationArticleListResponseDTO>> getQuotationArticles(
+            @PathVariable Long reviewArticleId,
+            @RequestParam int page,
+            @RequestParam int size,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        QuotationArticleListResponseDTO quotationArticleListResponseDTO =
+                articleViewService.getQuotationArticlesByReviewArticleId(reviewArticleId, page, size, userDetails);
+        return ApiResponse.success(SuccessStatus.GET_ARTICLE_LIST_SUCCESS, quotationArticleListResponseDTO);
     }
 
 }

--- a/src/main/java/com/core/book/api/article/controller/ArticleViewController.java
+++ b/src/main/java/com/core/book/api/article/controller/ArticleViewController.java
@@ -85,24 +85,4 @@ public class ArticleViewController {
         return ApiResponse.success(SuccessStatus.GET_ARTICLE_SUCCESS, qnaArticleDetailDTO);
     }
 
-    @Operation(
-            summary = "인용 게시글 목록 조회 API",
-            description = "감상평 게시글의 id를 기반으로 인용 게시글 목록을 조회합니다."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없습니다.")
-    })
-    @GetMapping("/quotation/{reviewArticleId}")
-    public ResponseEntity<ApiResponse<QuotationArticleListResponseDTO>> getQuotationArticles(
-            @PathVariable Long reviewArticleId,
-            @RequestParam int page,
-            @RequestParam int size,
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        QuotationArticleListResponseDTO quotationArticleListResponseDTO =
-                articleViewService.getQuotationArticlesByReviewArticleId(reviewArticleId, page, size, userDetails);
-        return ApiResponse.success(SuccessStatus.GET_ARTICLE_LIST_SUCCESS, quotationArticleListResponseDTO);
-    }
-
 }

--- a/src/main/java/com/core/book/api/article/dto/QuotationArticleCreateDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/QuotationArticleCreateDTO.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class QuotationArticleCreateDTO {
-    private Long reviewArticleId; // 인용할 감상평 게시글의 ID
+    private Long quotedArticleId; // 인용할 게시글의 ID
     private String content;       // 인용 내용
 }

--- a/src/main/java/com/core/book/api/article/dto/QuotationArticleCreateDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/QuotationArticleCreateDTO.java
@@ -1,0 +1,9 @@
+package com.core.book.api.article.dto;
+
+import lombok.Data;
+
+@Data
+public class QuotationArticleCreateDTO {
+    private Long reviewArticleId; // 인용할 감상평 게시글의 ID
+    private String content;       // 인용 내용
+}

--- a/src/main/java/com/core/book/api/article/dto/QuotationArticleListResponseDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/QuotationArticleListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.core.book.api.article.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class QuotationArticleListResponseDTO {
+    private List<QuotationArticleResponseDTO> quotations;  // 인용 게시글 목록
+    private boolean isLast;                                    // 마지막 페이지 여부
+    private int page;                                        // 현재 페이지 번호
+}

--- a/src/main/java/com/core/book/api/article/dto/QuotationArticleModifyDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/QuotationArticleModifyDTO.java
@@ -1,0 +1,8 @@
+package com.core.book.api.article.dto;
+
+import lombok.Data;
+
+@Data
+public class QuotationArticleModifyDTO {
+    private String content;
+}

--- a/src/main/java/com/core/book/api/article/dto/QuotationArticleResponseDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/QuotationArticleResponseDTO.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class QuotationArticleResponseDTO {
-    // 인용 게시글(QuotationArticle) 정보
+    // 인용 게시글 정보
     private Long quotationArticleId;       // 인용 게시글 id
     private Long memberId;                 // 인용 게시글 작성자 id
     private String profileImage;           // 인용 게시글 작성자 프로필 사진
@@ -18,14 +18,15 @@ public class QuotationArticleResponseDTO {
     private String date;                   // 작성일 (포맷팅된 날짜)
     private String content;                // 인용 게시글 내용
 
-    // 인용한 감상평 게시글(ReviewArticle) 정보
+    // 인용한 게시글 정보
     private Long originalArticleId;         // 인용한 게시글 id
-    private Long originalMemberId;         // 감상평 게시글 작성자 id
-    private String originalMemberProfileImage; // 감상평 게시글 작성자 프로필 사진
-    private ArticleType originalArticleType;     // 감상평 게시글 타입 (일반적으로 REVIEW)
-    private String bookId;                 // 감상평에 등록된 책의 id (ISBN)
+    private Long originalMemberId;         // 인용한 게시글 작성자 id
+    private String originalMemberNickname;  // 인용한 게시글 작성자 닉네임
+    private String originalMemberProfileImage; // 인용한 게시글 작성자 프로필 사진
+    private ArticleType originalArticleType;     // 인용한 게시글 타입
+    private String bookId;                 // 인용한 게시글에 등록된 책의 id (ISBN)
     private String bookImage;              // 책 이미지
     private String bookTitle;              // 책 이름
     private String bookAuthor;             // 책 저자
-    private String originalContent;        // 감상평 게시글 내용
+    private String originalContent;        // 인용한 게시글 내용
 }

--- a/src/main/java/com/core/book/api/article/dto/QuotationArticleResponseDTO.java
+++ b/src/main/java/com/core/book/api/article/dto/QuotationArticleResponseDTO.java
@@ -1,0 +1,31 @@
+package com.core.book.api.article.dto;
+
+import com.core.book.api.article.entity.ArticleType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuotationArticleResponseDTO {
+    // 인용 게시글(QuotationArticle) 정보
+    private Long quotationArticleId;       // 인용 게시글 id
+    private Long memberId;                 // 인용 게시글 작성자 id
+    private String profileImage;           // 인용 게시글 작성자 프로필 사진
+    private String nickname;               // 인용 게시글 작성자 닉네임
+    private long likeCnt;                // 좋아요 수
+    private long commentCnt;             // 댓글 수
+    private long quoCnt;                    // 인용 수 (quoCnt)
+    private String date;                   // 작성일 (포맷팅된 날짜)
+    private String content;                // 인용 게시글 내용
+
+    // 인용한 감상평 게시글(ReviewArticle) 정보
+    private Long originalArticleId;         // 인용한 게시글 id
+    private Long originalMemberId;         // 감상평 게시글 작성자 id
+    private String originalMemberProfileImage; // 감상평 게시글 작성자 프로필 사진
+    private ArticleType originalArticleType;     // 감상평 게시글 타입 (일반적으로 REVIEW)
+    private String bookId;                 // 감상평에 등록된 책의 id (ISBN)
+    private String bookImage;              // 책 이미지
+    private String bookTitle;              // 책 이름
+    private String bookAuthor;             // 책 저자
+    private String originalContent;        // 감상평 게시글 내용
+}

--- a/src/main/java/com/core/book/api/article/entity/Article.java
+++ b/src/main/java/com/core/book/api/article/entity/Article.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,20 +29,26 @@ public abstract class Article extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ArticleType type;
 
-    private long likeCnt; // 좋아요 수
-    private long commentCnt; // 댓글 수
-    private long quoCnt; // 인용 수
+    protected long likeCnt; // 좋아요 수
+    protected long commentCnt; // 댓글 수
+    protected long quoCnt; // 인용 수
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
     private Book book;
 
+    @OneToMany(mappedBy = "quotedArticle", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuotationArticle> quotationArticles = new ArrayList<>();
+
     public abstract String getContent();
     public abstract Member getMember();
 
-    public abstract Article increaseCommentCount();
-    public abstract Article decreaseCommentCount();
+    public abstract void increaseCommentCount();
+    public abstract void decreaseCommentCount();
 
-    public abstract Article increaseLikeCount();
-    public abstract Article decreaseLikeCount();
+    public abstract void increaseLikeCount();
+    public abstract void decreaseLikeCount();
+
+    public abstract void increaseQuoCount();
+    public abstract void decreaseQuoCount();
 }

--- a/src/main/java/com/core/book/api/article/entity/PhraseArticle.java
+++ b/src/main/java/com/core/book/api/article/entity/PhraseArticle.java
@@ -34,32 +34,38 @@ public class PhraseArticle extends Article {
 
     // 댓글 수 증가
     @Override
-    public PhraseArticle increaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() + 1)
-                .build();
+    public void increaseCommentCount() {
+        this.commentCnt++;
     }
 
     // 댓글 수 감소
     @Override
-    public PhraseArticle decreaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() - 1)
-                .build();
+    public void decreaseCommentCount() {
+        this.commentCnt--;
     }
 
     // 좋아요 증가
-    public Article increaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() + 1)
-                .build();
+    @Override
+    public void increaseLikeCount() {
+        this.likeCnt++;
     }
 
     // 좋아요 감소
-    public Article decreaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() - 1)
-                .build();
+    @Override
+    public void decreaseLikeCount() {
+        this.likeCnt--;
+    }
+
+    // 인용 수 증가
+    @Override
+    public void increaseQuoCount() {
+        this.quoCnt++;
+    }
+
+    // 인용 수 감소
+    @Override
+    public void decreaseQuoCount() {
+        this.quoCnt--;
     }
 
     @Override

--- a/src/main/java/com/core/book/api/article/entity/QnaArticle.java
+++ b/src/main/java/com/core/book/api/article/entity/QnaArticle.java
@@ -34,32 +34,38 @@ public class QnaArticle extends Article{
 
     // 댓글 수 증가
     @Override
-    public QnaArticle increaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() + 1)
-                .build();
+    public void increaseCommentCount() {
+        this.commentCnt++;
     }
 
     // 댓글 수 감소
     @Override
-    public QnaArticle decreaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() - 1)
-                .build();
+    public void decreaseCommentCount() {
+        this.commentCnt--;
     }
 
     // 좋아요 증가
-    public Article increaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() + 1)
-                .build();
+    @Override
+    public void increaseLikeCount() {
+        this.likeCnt++;
     }
 
     // 좋아요 감소
-    public Article decreaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() - 1)
-                .build();
+    @Override
+    public void decreaseLikeCount() {
+        this.likeCnt--;
+    }
+
+    // 인용 수 증가
+    @Override
+    public void increaseQuoCount() {
+        this.quoCnt++;
+    }
+
+    // 인용 수 감소
+    @Override
+    public void decreaseQuoCount() {
+        this.quoCnt--;
     }
 
     @Override

--- a/src/main/java/com/core/book/api/article/entity/QuotationArticle.java
+++ b/src/main/java/com/core/book/api/article/entity/QuotationArticle.java
@@ -24,37 +24,43 @@ public class QuotationArticle extends Article{
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_article_id")
-    private ReviewArticle reviewArticle;
+    @JoinColumn(name = "quoted_article_id")
+    private Article quotedArticle;
 
     // 댓글 수 증가
     @Override
-    public QuotationArticle increaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() + 1)
-                .build();
+    public void increaseCommentCount() {
+        this.commentCnt++;
     }
 
     // 댓글 수 감소
     @Override
-    public QuotationArticle decreaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() - 1)
-                .build();
+    public void decreaseCommentCount() {
+        this.commentCnt--;
     }
 
     // 좋아요 증가
-    public Article increaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() + 1)
-                .build();
+    @Override
+    public void increaseLikeCount() {
+        this.likeCnt++;
     }
 
     // 좋아요 감소
-    public Article decreaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() - 1)
-                .build();
+    @Override
+    public void decreaseLikeCount() {
+        this.likeCnt--;
+    }
+
+    // 인용 수 증가
+    @Override
+    public void increaseQuoCount() {
+        this.quoCnt++;
+    }
+
+    // 인용 수 감소
+    @Override
+    public void decreaseQuoCount() {
+        this.quoCnt--;
     }
 
     @Override

--- a/src/main/java/com/core/book/api/article/entity/QuotationArticle.java
+++ b/src/main/java/com/core/book/api/article/entity/QuotationArticle.java
@@ -1,54 +1,35 @@
 package com.core.book.api.article.entity;
 
-import com.core.book.api.article.dto.ReviewArticleCreateDTO;
-import com.core.book.api.book.entity.Book;
 import com.core.book.api.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @SuperBuilder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "REVIEW_ARTICLE")
-public class ReviewArticle extends Article {
+@Table(name = "QUOTATION_ARTICLE")
+public class QuotationArticle extends Article{
 
     @Column(columnDefinition = "TEXT")
     private String content; // 게시글 내용
-
-    private String oneLineReview; //한줄평 리뷰
-    private float rating; // 평점
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private Member member;
 
-    // 추후 감상평 게시글에서 자신을 인용한 인용 게시글 목록을 관리할 수 있도록 코드 추가
-    @OneToMany(mappedBy = "reviewArticle", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<QuotationArticle> quotationArticles = new ArrayList<>();
-
-    public void addQuotationArticle(QuotationArticle quotationArticle) {
-        quotationArticles.add(quotationArticle);
-    }
-
-
-    public ReviewArticle update(ReviewArticleCreateDTO dto, Book newBook) {
-        return this.toBuilder()
-                .content(dto.getContent())
-                .oneLineReview(dto.getOneLineReview())
-                .rating(dto.getRating())
-                .book(newBook)
-                .build();
-    }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_article_id")
+    private ReviewArticle reviewArticle;
 
     // 댓글 수 증가
     @Override
-    public ReviewArticle increaseCommentCount() {
+    public QuotationArticle increaseCommentCount() {
         return this.toBuilder()
                 .commentCnt(this.getCommentCnt() + 1)
                 .build();
@@ -56,7 +37,7 @@ public class ReviewArticle extends Article {
 
     // 댓글 수 감소
     @Override
-    public ReviewArticle decreaseCommentCount() {
+    public QuotationArticle decreaseCommentCount() {
         return this.toBuilder()
                 .commentCnt(this.getCommentCnt() - 1)
                 .build();
@@ -85,5 +66,4 @@ public class ReviewArticle extends Article {
     public Member getMember() {
         return this.member;
     }
-
 }

--- a/src/main/java/com/core/book/api/article/entity/ReviewArticle.java
+++ b/src/main/java/com/core/book/api/article/entity/ReviewArticle.java
@@ -48,32 +48,38 @@ public class ReviewArticle extends Article {
 
     // 댓글 수 증가
     @Override
-    public ReviewArticle increaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() + 1)
-                .build();
+    public void increaseCommentCount() {
+        this.commentCnt++;
     }
 
     // 댓글 수 감소
     @Override
-    public ReviewArticle decreaseCommentCount() {
-        return this.toBuilder()
-                .commentCnt(this.getCommentCnt() - 1)
-                .build();
+    public void decreaseCommentCount() {
+        this.commentCnt--;
     }
 
     // 좋아요 증가
-    public Article increaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() + 1)
-                .build();
+    @Override
+    public void increaseLikeCount() {
+        this.likeCnt++;
     }
 
     // 좋아요 감소
-    public Article decreaseLikeCount() {
-        return this.toBuilder()
-                .likeCnt(this.getLikeCnt() - 1)
-                .build();
+    @Override
+    public void decreaseLikeCount() {
+        this.likeCnt--;
+    }
+
+    // 인용 수 증가
+    @Override
+    public void increaseQuoCount() {
+        this.quoCnt++;
+    }
+
+    // 인용 수 감소
+    @Override
+    public void decreaseQuoCount() {
+        this.quoCnt--;
     }
 
     @Override

--- a/src/main/java/com/core/book/api/article/repository/ArticleLikeRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/ArticleLikeRepository.java
@@ -1,12 +1,15 @@
 package com.core.book.api.article.repository;
 
+import com.core.book.api.article.entity.Article;
 import com.core.book.api.article.entity.ArticleLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
     Optional<ArticleLike> findByArticleIdAndMemberId(Long articleId, Long userId);
+    List<ArticleLike> findByArticle(Article article);
 }

--- a/src/main/java/com/core/book/api/article/repository/QnaArticleContentRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/QnaArticleContentRepository.java
@@ -1,10 +1,14 @@
 package com.core.book.api.article.repository;
 
+import com.core.book.api.article.entity.QnaArticle;
 import com.core.book.api.article.entity.QnaArticleContent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface QnaArticleContentRepository extends JpaRepository<QnaArticleContent, Long> {
+    List<QnaArticleContent> findByQnaArticle(QnaArticle qnaArticle);
 
 }

--- a/src/main/java/com/core/book/api/article/repository/QuotationArticleRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/QuotationArticleRepository.java
@@ -1,0 +1,11 @@
+package com.core.book.api.article.repository;
+
+import com.core.book.api.article.entity.QuotationArticle;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuotationArticleRepository extends JpaRepository<QuotationArticle, Long> {
+    Page<QuotationArticle> findByReviewArticleId(Long reviewArticleId, Pageable pageable);
+
+}

--- a/src/main/java/com/core/book/api/article/repository/QuotationArticleRepository.java
+++ b/src/main/java/com/core/book/api/article/repository/QuotationArticleRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuotationArticleRepository extends JpaRepository<QuotationArticle, Long> {
-    Page<QuotationArticle> findByReviewArticleId(Long reviewArticleId, Pageable pageable);
+    Page<QuotationArticle> findByQuotedArticleId(Long quotedArticleId, Pageable pageable);
 
 }

--- a/src/main/java/com/core/book/api/article/service/ArticleCreateService.java
+++ b/src/main/java/com/core/book/api/article/service/ArticleCreateService.java
@@ -7,6 +7,7 @@ import com.core.book.api.article.entity.*;
 import com.core.book.api.article.repository.PhraseArticleRepository;
 import com.core.book.api.article.dto.*;
 import com.core.book.api.article.repository.QnaArticleRepository;
+import com.core.book.api.article.repository.QuotationArticleRepository;
 import com.core.book.api.article.repository.ReviewArticleRepository;
 import com.core.book.api.book.dto.UserBookTagDTO;
 import com.core.book.api.book.entity.Book;
@@ -19,6 +20,7 @@ import com.core.book.common.exception.NotFoundException;
 import com.core.book.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.HashMap;
@@ -31,6 +33,7 @@ public class ArticleCreateService {
 
     private final PhraseArticleRepository phraseArticleRepository;
     private final ReviewArticleRepository reviewArticleRepository;
+    private final QuotationArticleRepository quotationArticleRepository;
     private final MemberRepository memberRepository;
     private final ReadBooksRepository readBooksRepository;
     private final BookRepository bookRepository;
@@ -38,6 +41,7 @@ public class ArticleCreateService {
     private final UserBookTagService userBookTagService;
 
     // 감상평 게시글 생성
+    @Transactional
     public void createReviewArticle(ReviewArticleCreateDTO reviewArticleCreateDTO, Long userId) {
         // 해당 유저를 찾을 수 없을 경우 예외처리
         Member member = memberRepository.findById(userId)
@@ -116,8 +120,8 @@ public class ArticleCreateService {
         return response;
     }
 
-
     // 인상깊은구절 게시글 생성
+    @Transactional
     public void createPhraseArticle(PhraseArticleCreateDTO phraseArticleCreateDTO, Long userId) {
         // 해당 유저를 찾을 수 없을 경우 예외처리
         Member member = memberRepository.findById(userId)
@@ -161,6 +165,7 @@ public class ArticleCreateService {
     }
 
     // QnA 게시글 생성
+    @Transactional
     public void createQnaArticle(QnaArticleCreateDTO qnaArticleCreateDTO, Long userId) {
         // 해당 유저를 찾을 수 없을 경우 예외처리
         Member member = memberRepository.findById(userId)
@@ -201,5 +206,34 @@ public class ArticleCreateService {
         }
 
         qnaArticleRepository.save(qnaArticle);
+    }
+
+    // 인용 게시글 생성
+    @Transactional
+    public void createQuotationArticle(QuotationArticleCreateDTO quotationArticleCreateDTO, Long userId) {
+        // 현재 사용자 조회
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.USER_NOTFOUND_EXCEPTION.getMessage()));
+
+        // 인용할 감상평 게시글 조회
+        ReviewArticle reviewArticle = reviewArticleRepository.findById(quotationArticleCreateDTO.getReviewArticleId())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.ARTICLE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        QuotationArticle quotationArticle = QuotationArticle.builder()
+                .content(quotationArticleCreateDTO.getContent())
+                .likeCnt(0)
+                .quoCnt(0)
+                .commentCnt(0)
+                .type(ArticleType.QUOTATION)
+                .member(member)
+                .reviewArticle(reviewArticle)
+                .book(reviewArticle.getBook())
+                .build();
+
+        quotationArticleRepository.save(quotationArticle);
+
+        // 양방향 연관관계 설정: 감상평 게시글에 인용 게시글 추가
+        reviewArticle.addQuotationArticle(quotationArticle);
+        reviewArticleRepository.save(reviewArticle);
     }
 }

--- a/src/main/java/com/core/book/api/article/service/ArticleDeleteService.java
+++ b/src/main/java/com/core/book/api/article/service/ArticleDeleteService.java
@@ -1,17 +1,20 @@
 package com.core.book.api.article.service;
 
 import com.core.book.api.article.entity.PhraseArticle;
+import com.core.book.api.article.entity.QuotationArticle;
 import com.core.book.api.article.entity.ReviewArticle;
 import com.core.book.api.article.repository.PhraseArticleRepository;
 import com.core.book.api.article.entity.QnaArticle;
 import com.core.book.api.article.repository.QnaArticleRepository;
 import com.core.book.api.article.repository.ReviewArticleRepository;
+import com.core.book.api.article.repository.QuotationArticleRepository;
 import com.core.book.api.book.entity.UserBookTag;
 import com.core.book.api.book.repository.UserBookTagRepository;
 import com.core.book.common.exception.NotFoundException;
 import com.core.book.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -22,9 +25,11 @@ public class ArticleDeleteService {
     private final ReviewArticleRepository reviewArticleRepository;
     private final PhraseArticleRepository phraseArticleRepository;
     private final QnaArticleRepository qnaArticleRepository;
+    private final QuotationArticleRepository quotationArticleRepository;
     private final UserBookTagRepository userBookTagRepository;
 
     //감상평 게시글 삭제
+    @Transactional
     public void deleteReviewArticle(Long articleId, Long userId) {
         ReviewArticle reviewArticle = reviewArticleRepository.findById(articleId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.ARTICLE_NOT_FOUND_EXCEPTION.getMessage()));
@@ -47,6 +52,7 @@ public class ArticleDeleteService {
     }
 
     // 인상깊은구절 게시글 삭제
+    @Transactional
     public void deletePhraseArticle(Long articleId, Long userId) {
         PhraseArticle phraseArticle = phraseArticleRepository.findById(articleId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.ARTICLE_NOT_FOUND_EXCEPTION.getMessage()));
@@ -60,6 +66,7 @@ public class ArticleDeleteService {
     }
 
     // 인상깊은구절 게시글 삭제
+    @Transactional
     public void deleteQnaArticle(Long articleId, Long userId) {
         QnaArticle qnaArticle = qnaArticleRepository.findById(articleId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.ARTICLE_NOT_FOUND_EXCEPTION.getMessage()));
@@ -70,6 +77,20 @@ public class ArticleDeleteService {
         }
 
         qnaArticleRepository.delete(qnaArticle);
+    }
+
+    // 인용 게시글 삭제
+    @Transactional
+    public void deleteQuotationArticle(Long articleId, Long userId) {
+        QuotationArticle quotationArticle = quotationArticleRepository.findById(articleId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.ARTICLE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        // 게시글 작성자와 삭제 요청자가 다를 경우 예외 처리
+        if (!quotationArticle.getMember().getId().equals(userId)) {
+            throw new NotFoundException(ErrorStatus.ARTICLE_DELETE_NOT_SAME_USER_EXCEPTION.getMessage());
+        }
+
+        quotationArticleRepository.delete(quotationArticle);
     }
 
 }

--- a/src/main/java/com/core/book/api/article/service/ArticleDeleteService.java
+++ b/src/main/java/com/core/book/api/article/service/ArticleDeleteService.java
@@ -1,15 +1,13 @@
 package com.core.book.api.article.service;
 
-import com.core.book.api.article.entity.PhraseArticle;
-import com.core.book.api.article.entity.QuotationArticle;
-import com.core.book.api.article.entity.ReviewArticle;
-import com.core.book.api.article.repository.PhraseArticleRepository;
-import com.core.book.api.article.entity.QnaArticle;
-import com.core.book.api.article.repository.QnaArticleRepository;
-import com.core.book.api.article.repository.ReviewArticleRepository;
-import com.core.book.api.article.repository.QuotationArticleRepository;
+import com.core.book.api.article.entity.*;
+import com.core.book.api.article.repository.*;
 import com.core.book.api.book.entity.UserBookTag;
 import com.core.book.api.book.repository.UserBookTagRepository;
+import com.core.book.api.comment.entity.Comment;
+import com.core.book.api.comment.entity.QnaComment;
+import com.core.book.api.comment.repository.CommentRepository;
+import com.core.book.api.comment.repository.QnaCommentRepository;
 import com.core.book.common.exception.NotFoundException;
 import com.core.book.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +20,63 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ArticleDeleteService {
 
+    private final CommentRepository commentRepository;
+    private final QnaArticleContentRepository qnaArticleContentRepository;
+    private final QnaCommentRepository qnaCommentRepository;
+    private final ArticleLikeRepository articleLikeRepository;
     private final ReviewArticleRepository reviewArticleRepository;
     private final PhraseArticleRepository phraseArticleRepository;
     private final QnaArticleRepository qnaArticleRepository;
     private final QuotationArticleRepository quotationArticleRepository;
     private final UserBookTagRepository userBookTagRepository;
+
+    // 게시글에 연관된 좋아요 삭제
+    @Transactional
+    protected void deleteArticleLikesForArticle(Article article) {
+        List<ArticleLike> articleLikes = articleLikeRepository.findByArticle(article);
+        if (articleLikes != null && !articleLikes.isEmpty()) {
+            articleLikeRepository.deleteAll(articleLikes);
+        }
+    }
+
+    // 삭제할 원 게시글을 인용한 인용 게시글들을 삭제
+    @Transactional
+    protected void deleteQuotationArticlesForArticle(Article article) {
+        List<QuotationArticle> quotationArticles = article.getQuotationArticles();
+        if (quotationArticles != null && !quotationArticles.isEmpty()) {
+            for (QuotationArticle qa : quotationArticles) {
+                // 하위 인용 게시글 재귀 삭제
+                deleteQuotationArticlesForArticle(qa);
+
+                // 인용 게시글에 달린 댓글 전부 삭제
+                deleteCommentsForArticle(qa);
+
+                // 인용 게시글에 달린 좋아요 전부 삭제
+                deleteArticleLikesForArticle(qa);
+            }
+            quotationArticleRepository.deleteAll(quotationArticles);
+        }
+    }
+
+    // 일반 댓글 삭제
+    @Transactional
+    protected void deleteCommentsForArticle(Article article) {
+        commentRepository.deleteAllByArticleIdNative(article.getId());
+    }
+
+    // QnA 댓글 삭제
+    @Transactional
+    protected void deleteQnaCommentsForQnaArticle(QnaArticle qnaArticle) {
+        List<QnaArticleContent> contents = qnaArticleContentRepository.findByQnaArticle(qnaArticle);
+        if (contents != null && !contents.isEmpty()) {
+            for (QnaArticleContent content : contents) {
+                List<QnaComment> qnaComments = qnaCommentRepository.findByQnaArticleContent(content);
+                if (qnaComments != null && !qnaComments.isEmpty()) {
+                    qnaCommentRepository.deleteAll(qnaComments);
+                }
+            }
+        }
+    }
 
     //감상평 게시글 삭제
     @Transactional
@@ -48,6 +98,11 @@ public class ArticleDeleteService {
             userBookTagRepository.deleteAll(userBookTags);
         }
 
+        // 연관된 좋아요, 댓글, 인용 삭제
+        deleteQuotationArticlesForArticle(reviewArticle);
+        deleteCommentsForArticle(reviewArticle);
+        deleteArticleLikesForArticle(reviewArticle);
+
         reviewArticleRepository.delete(reviewArticle);
     }
 
@@ -62,10 +117,15 @@ public class ArticleDeleteService {
             throw new NotFoundException(ErrorStatus.ARTICLE_DELETE_NOT_SAME_USER_EXCEPTION.getMessage());
         }
 
+        // 연관된 좋아요, 댓글, 인용 삭제
+        deleteQuotationArticlesForArticle(phraseArticle);
+        deleteCommentsForArticle(phraseArticle);
+        deleteArticleLikesForArticle(phraseArticle);
+
         phraseArticleRepository.delete(phraseArticle);
     }
 
-    // 인상깊은구절 게시글 삭제
+    // QnA 게시글 삭제
     @Transactional
     public void deleteQnaArticle(Long articleId, Long userId) {
         QnaArticle qnaArticle = qnaArticleRepository.findById(articleId)
@@ -75,6 +135,12 @@ public class ArticleDeleteService {
         if (!qnaArticle.getMember().getId().equals(userId)) {
             throw new NotFoundException(ErrorStatus.ARTICLE_DELETE_NOT_SAME_USER_EXCEPTION.getMessage());
         }
+
+        // 연관된 좋아요, 댓글, 인용 삭제
+        deleteQuotationArticlesForArticle(qnaArticle);
+        deleteCommentsForArticle(qnaArticle);
+        deleteQnaCommentsForQnaArticle(qnaArticle);
+        deleteArticleLikesForArticle(qnaArticle);
 
         qnaArticleRepository.delete(qnaArticle);
     }
@@ -89,6 +155,15 @@ public class ArticleDeleteService {
         if (!quotationArticle.getMember().getId().equals(userId)) {
             throw new NotFoundException(ErrorStatus.ARTICLE_DELETE_NOT_SAME_USER_EXCEPTION.getMessage());
         }
+
+        // 연관된 좋아요, 댓글, 인용 삭제
+        deleteQuotationArticlesForArticle(quotationArticle);
+        deleteCommentsForArticle(quotationArticle);
+        deleteArticleLikesForArticle(quotationArticle);
+
+        // 원 게시글 인용 수 감소
+        Article quotedArticle = quotationArticle.getQuotedArticle();
+        quotedArticle.decreaseQuoCount();
 
         quotationArticleRepository.delete(quotationArticle);
     }

--- a/src/main/java/com/core/book/api/article/service/ArticleModifyService.java
+++ b/src/main/java/com/core/book/api/article/service/ArticleModifyService.java
@@ -10,6 +10,7 @@ import com.core.book.api.article.repository.PhraseArticleRepository;
 import com.core.book.api.article.dto.*;
 import com.core.book.api.article.entity.*;
 import com.core.book.api.article.repository.QnaArticleRepository;
+import com.core.book.api.article.repository.QuotationArticleRepository;
 import com.core.book.api.article.repository.ReviewArticleRepository;
 import com.core.book.api.book.dto.UserBookTagDTO;
 import com.core.book.api.book.entity.Book;
@@ -20,6 +21,7 @@ import com.core.book.common.exception.NotFoundException;
 import com.core.book.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,12 +32,14 @@ public class ArticleModifyService {
 
     private final ReviewArticleRepository reviewArticleRepository;
     private final PhraseArticleRepository phraseArticleRepository;
+    private final QuotationArticleRepository quotationArticleRepository;
     private final ReadBooksRepository readBooksRepository;
     private final BookRepository bookRepository;
     private final QnaArticleRepository qnaArticleRepository;
     private final UserBookTagService userBookTagService;
 
     // 감상평 게시글 수정
+    @Transactional
     public void modifyReviewArticle(Long articleId, ReviewArticleCreateDTO reviewArticleCreateDTO, Long userId) {
 
         // 게시글 조회
@@ -98,6 +102,7 @@ public class ArticleModifyService {
     }
 
     // 인상깊은구절 게시글 수정
+    @Transactional
     public void modifyPhraseArticle(Long articleId, PhraseArticleCreateDTO phraseArticleCreateDTO, Long userId) {
 
         // 게시글 조회
@@ -142,6 +147,7 @@ public class ArticleModifyService {
     }
 
     // QnA 게시글 수정
+    @Transactional
     public void modifyQnaArticle(Long articleId, QnaArticleCreateDTO qnaArticleCreateDTO, Long userId) {
 
         // 게시글 조회
@@ -170,5 +176,24 @@ public class ArticleModifyService {
         }
 
         qnaArticleRepository.save(qnaArticle);
+    }
+
+    // 인용 게시글 수정
+    @Transactional
+    public void modifyQuotationArticle(Long articleId, QuotationArticleModifyDTO quotationArticleModifyDTO, Long userId) {
+
+        QuotationArticle quotationArticle = quotationArticleRepository.findById(articleId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.ARTICLE_NOT_FOUND_EXCEPTION.getMessage()));
+
+        // 게시글 작성자와 수정 요청자가 다르면 예외 처리
+        if (!quotationArticle.getMember().getId().equals(userId)) {
+            throw new NotFoundException(ErrorStatus.ARTICLE_MODIFY_NOT_SAME_USER_EXCEPTION.getMessage());
+        }
+
+        QuotationArticle updatedArticle = quotationArticle.toBuilder()
+                .content(quotationArticleModifyDTO.getContent())
+                .build();
+
+        quotationArticleRepository.save(updatedArticle);
     }
 }

--- a/src/main/java/com/core/book/api/article/service/ArticleService.java
+++ b/src/main/java/com/core/book/api/article/service/ArticleService.java
@@ -34,14 +34,14 @@ public class ArticleService {
 
         if (existingLike.isPresent()) {
             articleLikeRepository.delete(existingLike.get());
-            article = article.decreaseLikeCount();
+            article.decreaseLikeCount();
         } else {
             ArticleLike articleLike = ArticleLike.builder()
                     .article(article)
                     .member(member)
                     .build();
             articleLikeRepository.save(articleLike);
-            article = article.increaseLikeCount();
+            article.increaseLikeCount();
         }
 
         articleRepository.save(article);

--- a/src/main/java/com/core/book/api/comment/repository/CommentRepository.java
+++ b/src/main/java/com/core/book/api/comment/repository/CommentRepository.java
@@ -3,9 +3,16 @@ package com.core.book.api.comment.repository;
 import com.core.book.api.article.entity.Article;
 import com.core.book.api.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticle(Article article);
+
+    @Modifying
+    @Query(value = "DELETE FROM comment WHERE article_id = :articleId", nativeQuery = true)
+    void deleteAllByArticleIdNative(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/core/book/api/comment/service/CommentService.java
+++ b/src/main/java/com/core/book/api/comment/service/CommentService.java
@@ -58,8 +58,7 @@ public class CommentService {
         commentRepository.save(comment);
 
         // 댓글 수 증가
-        Article updatedArticle = article.increaseCommentCount();
-        articleRepository.save(updatedArticle);
+        article.increaseCommentCount();
     }
 
     //댓글 조회
@@ -111,8 +110,7 @@ public class CommentService {
 
         // 댓글 수 감소
         Article article = comment.getArticle();
-        Article updatedArticle = article.decreaseCommentCount();
-        articleRepository.save(updatedArticle);
+        article.decreaseCommentCount();
     }
 
     // QnA 답변(댓글) 생성
@@ -144,10 +142,8 @@ public class CommentService {
                 .build();
         qnaCommentRepository.save(qnaComment);
 
-        // QnAArticle 댓글 수 증가 로직
-        // (QnaArticle의 increaseCommentCount() 호출 후 빌더로 객체를 새로 생성하여 저장)
-        QnaArticle updatedQnaArticle = qnaArticle.increaseCommentCount();
-        articleRepository.save(updatedQnaArticle);
+        // 댓글 수 증가 로직
+        qnaArticle.increaseCommentCount();
     }
 
     // QnA 답변(댓글) 조회
@@ -197,12 +193,9 @@ public class CommentService {
 
         qnaCommentRepository.delete(qnaComment);
 
-        // QnAArticle 댓글 수 감소 로직
-        // (QnaArticle의 decreaseCommentCount() 호출 후 빌더로 객체를 새로 생성하여 저장)
+        // 댓글 수 감소
         QnaArticle qnaArticle = qnaComment.getQnaArticleContent().getQnaArticle();
-
-        QnaArticle updatedQnaArticle = qnaArticle.decreaseCommentCount();
-        articleRepository.save(updatedQnaArticle);
+        qnaArticle.decreaseCommentCount();
 
     }
 }

--- a/src/main/java/com/core/book/common/response/ErrorStatus.java
+++ b/src/main/java/com/core/book/common/response/ErrorStatus.java
@@ -39,6 +39,7 @@ public enum ErrorStatus {
     MISSING_COMMENT_ID(HttpStatus.BAD_REQUEST,"댓글 ID가 입력되지 않았습니다."),
     BOOKSHELF_MODIFY_NOT_SAME_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "책장 소유자와 수정 요청자가 다릅니다."),
     BOOKSHELF_DELETE_NOT_SAME_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "책장 소유자와 삭제 요청자가 다릅니다."),
+    NOT_ALLOW_GET_OTHER_USER_INFO(HttpStatus.BAD_REQUEST,"사용자에 의해 비공개 설정 되었습니다."),
 
     /**
      * 401 UNAUTHORIZED


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #153

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 인용 게시글 등록,수정,삭제,조회 기능을 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 각 게시글, 댓글 등등 현재 구현 단계에서는 하드삭제(즉시 삭제)로 구현되어있지만 추후 배포단계에서 법률적인 문제 등으로 인해 리팩토링 단계에서 소프트삭제(실질적인 삭제가 아닌 필드를 통한 논리적 삭제)로 변경해야합니다. 또한 추후 IP주소를 수집해야하는 로직도 추가해야합니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[ 게시글 등록 ]
![image](https://github.com/user-attachments/assets/396c4955-f3fc-4456-a5d4-78b49b90f10c)

[ 게시글 조회 ]
![image](https://github.com/user-attachments/assets/3ef554c7-0916-4189-a9b1-7c227aafb9bc)

[ 게시글 수정 ]
![image](https://github.com/user-attachments/assets/a33b3e35-4bba-41ff-81f4-3a26bd89fc6c)

[ 게시글 삭제 ]
![image](https://github.com/user-attachments/assets/59b4cec8-2f77-4c30-999a-ef5f04f13b33)
