### PR TITLE
[FIX] 평점 삭제 시 평균 평점 갱신

### DIFF
--- a/src/main/java/com/core/book/api/article/service/ArticleDeleteService.java
+++ b/src/main/java/com/core/book/api/article/service/ArticleDeleteService.java
@@ -2,9 +2,10 @@ package com.core.book.api.article.service;
 
 import com.core.book.api.article.entity.*;
 import com.core.book.api.article.repository.*;
+import com.core.book.api.book.entity.Book;
 import com.core.book.api.book.entity.UserBookTag;
+import com.core.book.api.book.repository.BookRepository;
 import com.core.book.api.book.repository.UserBookTagRepository;
-import com.core.book.api.comment.entity.Comment;
 import com.core.book.api.comment.entity.QnaComment;
 import com.core.book.api.comment.repository.CommentRepository;
 import com.core.book.api.comment.repository.QnaCommentRepository;
@@ -29,6 +30,7 @@ public class ArticleDeleteService {
     private final QnaArticleRepository qnaArticleRepository;
     private final QuotationArticleRepository quotationArticleRepository;
     private final UserBookTagRepository userBookTagRepository;
+    private final BookRepository bookRepository;
 
     // 게시글에 연관된 좋아요 삭제
     @Transactional
@@ -104,6 +106,32 @@ public class ArticleDeleteService {
         deleteArticleLikesForArticle(reviewArticle);
 
         reviewArticleRepository.delete(reviewArticle);
+
+        updateRatingAverageAfterDeletion(reviewArticle.getBook(), reviewArticle.getRating());
+    }
+
+    // 평점이 삭제된 경우 평균 평점 갱신
+    public void updateRatingAverageAfterDeletion(Book book, double removed_rating) {
+        int ratingCount = book.getRatingCount();
+
+        if (ratingCount <= 1) {
+            // 평점이 1개뿐이면 삭제 후 평균을 0으로 설정
+            book = book.toBuilder()
+                    .ratingAverage(0.0f)
+                    .ratingCount(0)
+                    .build();
+        } else {
+            // 새로운 평균 평점 계산
+            float new_rating_average = (float) ((book.getRatingAverage() * ratingCount - removed_rating) / (ratingCount - 1));
+            new_rating_average = (float) (Math.round(new_rating_average * 100) / 100.0);
+
+            book = book.toBuilder()
+                    .ratingAverage(new_rating_average)
+                    .ratingCount(ratingCount - 1)
+                    .build();
+        }
+
+        bookRepository.save(book);
     }
 
     // 인상깊은구절 게시글 삭제

--- a/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
+++ b/src/main/java/com/core/book/api/bookshelf/service/BookShelfService.java
@@ -484,6 +484,33 @@ public class BookShelfService {
         }
 
         readBooksRepository.delete(readBooks);
+
+        // 평균 평점 갱신
+        updateRatingAverageAfterDeletion(readBooks.getBook(), readBooks.getRating());
+    }
+
+    // 평점이 삭제된 경우 평균 평점 갱신
+    public void updateRatingAverageAfterDeletion(Book book, double removed_rating) {
+        int ratingCount = book.getRatingCount();
+
+        if (ratingCount <= 1) {
+            // 평점이 1개뿐이면 삭제 후 평균을 0으로 설정
+            book = book.toBuilder()
+                    .ratingAverage(0.0f)
+                    .ratingCount(0)
+                    .build();
+        } else {
+            // 새로운 평균 평점 계산
+            float new_rating_average = (float) ((book.getRatingAverage() * ratingCount - removed_rating) / (ratingCount - 1));
+            new_rating_average = (float) (Math.round(new_rating_average * 100) / 100.0);
+
+            book = book.toBuilder()
+                    .ratingAverage(new_rating_average)
+                    .ratingCount(ratingCount - 1)
+                    .build();
+        }
+
+        bookRepository.save(book);
     }
 
     @Transactional


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #158 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 책장 삭제 시, 삭제되는 평점을 평균 평점에 반영하였습니다. 
- 감상평 게시글 삭제 시, 삭제되는 평점을 평균 평점에 반영하였습니다. 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 평점 계산 메서드 코드 리팩토링 예정입니다

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
1. 게시글 생성 ->  평점 5.0 입력 -> 평균 평점 ((1.0+5.0+5.0+5.0)/4=4.0)
![image](https://github.com/user-attachments/assets/fb37ac83-0f8b-448e-9dc9-2f9f0c004b33)

2. 게시글 삭제 -> 평점 5.0 삭제 -> 평균 평점 ((1.0+5.0+5.0)/3=3.66....)
![image](https://github.com/user-attachments/assets/3e4f9e2b-c228-4310-b547-f023d82c565b)
![image](https://github.com/user-attachments/assets/6c1bc7fa-7b29-4f81-b8bb-567b274dc4ea)
